### PR TITLE
[Fix] Correct scene assignment from load/unload operations

### DIFF
--- a/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
@@ -98,4 +98,9 @@ namespace MyGameDevTools.SceneLoading
         /// <returns>A loaded scene with the given <paramref name="name"/>.</returns>
         Scene GetLoadedSceneByName(string name);
     }
+
+    internal interface ISceneManagerReporter
+    {
+        bool IsUnloadingScenes { get; }
+    }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
@@ -58,7 +58,7 @@ namespace MyGameDevTools.SceneLoading
                 return default;
 
             for (int i = SceneCount - 1; i >= 0; i--)
-                if (!_unloadingScenes.Contains(_loadedScenes[i]))
+                if (!_unloadingScenes.Contains(_loadedScenes[i]) && _loadedScenes[i].isLoaded)
                     return _loadedScenes[i];
 
             return default;
@@ -77,9 +77,6 @@ namespace MyGameDevTools.SceneLoading
         public async ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null)
         {
             var operation = GetLoadSceneOperation(sceneInfo);
-            Scene loadedScene = default;
-
-            UnitySceneManager.sceneLoaded += registerLoadedScene;
 
 #if USE_UNITASK
             await operation.ToUniTask(progress);
@@ -91,7 +88,7 @@ namespace MyGameDevTools.SceneLoading
             }
 #endif
 
-            UnitySceneManager.sceneLoaded -= registerLoadedScene;
+            var loadedScene = GetLastUnityLoadedSceneByInfo(sceneInfo);
 
             _loadedScenes.Add(loadedScene);
             SceneLoaded?.Invoke(loadedScene);
@@ -100,22 +97,17 @@ namespace MyGameDevTools.SceneLoading
                 SetActiveScene(loadedScene);
 
             return loadedScene;
-
-            void registerLoadedScene(Scene scene, LoadSceneMode loadSceneMode)
-            {
-                if (sceneInfo.IsReferenceToScene(scene))
-                    loadedScene = scene;
-            }
         }
 
         public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo)
         {
-            var scene = GetLastLoadedSceneByInfo(sceneInfo);
-            if (!_loadedScenes.Contains(scene))
-                throw new InvalidOperationException($"Cannot unload the scene \"{scene.name}\" that has not been loaded through this {GetType().Name}.");
+            var scene = GetLastSceneByInfo(sceneInfo);
             if (_unloadingScenes.Contains(scene))
                 return await WaitForSceneUnload(scene);
+            if (!_loadedScenes.Contains(scene))
+                throw new InvalidOperationException($"Cannot unload the scene \"{scene.name}\" that has not been loaded through this {GetType().Name}.");
 
+            _loadedScenes.Remove(scene);
             _unloadingScenes.Add(scene);
             var operation = GetUnloadSceneOperation(sceneInfo);
 #if USE_UNITASK
@@ -126,7 +118,6 @@ namespace MyGameDevTools.SceneLoading
 #endif
 
             _unloadingScenes.Remove(scene);
-            _loadedScenes.Remove(scene);
             if (_activeScene == scene)
                 SetActiveScene(GetLastLoadedScene());
 
@@ -170,16 +161,37 @@ namespace MyGameDevTools.SceneLoading
                 throw new Exception($"Unexpected {nameof(ILoadSceneInfo.Reference)} type.");
         }
 
-        Scene GetLastLoadedSceneByInfo(ILoadSceneInfo sceneInfo)
+        Scene GetLastSceneByInfo(ILoadSceneInfo sceneInfo)
         {
             var sceneCount = SceneCount;
-            for (int i = sceneCount - 1; i >= 0; i--)
+            int i;
+            for (i = sceneCount - 1; i >= 0; i--)
             {
                 var scene = _loadedScenes[i];
                 if (sceneInfo.IsReferenceToScene(scene))
                     return scene;
             }
-            throw new ArgumentException($"Could not find any loaded scene with the provided ILoadSceneInfo: {sceneInfo.Reference}");
+
+            sceneCount = _unloadingScenes.Count;
+            for (i = 0; i < sceneCount; i++)
+            {
+                var scene = _unloadingScenes[i];
+                if (sceneInfo.IsReferenceToScene(scene))
+                    return scene;
+            }
+            throw new ArgumentException($"Could not find any scene with the provided ILoadSceneInfo: {sceneInfo}");
+        }
+
+        Scene GetLastUnityLoadedSceneByInfo(ILoadSceneInfo sceneInfo)
+        {
+            var sceneCount = UnitySceneManager.sceneCount;
+            for (int i = sceneCount - 1; i >= 0; i--)
+            {
+                var scene = UnitySceneManager.GetSceneAt(i);
+                if (scene.isLoaded && sceneInfo.IsReferenceToScene(scene))
+                    return scene;
+            }
+            throw new ArgumentException($"Could not find any loaded scene in the Unity Scene Manager with the provided ILoadSceneInfo: {sceneInfo}");
         }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
@@ -12,19 +12,23 @@ using Cysharp.Threading.Tasks;
 #endif
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnitySceneManager = UnityEngine.SceneManagement.SceneManager;
 
+[assembly: InternalsVisibleTo("MyGameDevTools.SceneLoading.Tests")]
+
 namespace MyGameDevTools.SceneLoading
 {
-    public class SceneManager : ISceneManager
+    public class SceneManager : ISceneManager, ISceneManagerReporter
     {
         public event Action<Scene, Scene> ActiveSceneChanged;
         public event Action<Scene> SceneUnloaded;
         public event Action<Scene> SceneLoaded;
 
+        public bool IsUnloadingScenes => _unloadingScenes.Count > 0;
         public int SceneCount => _loadedScenes.Count;
 
         readonly List<Scene> _unloadingScenes = new List<Scene>();

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
@@ -22,12 +22,13 @@ using UnitySceneManager = UnityEngine.SceneManagement.SceneManager;
 
 namespace MyGameDevTools.SceneLoading
 {
-    public class SceneManagerAddressable : ISceneManager
+    public class SceneManagerAddressable : ISceneManager, ISceneManagerReporter
     {
         public event Action<Scene, Scene> ActiveSceneChanged;
         public event Action<Scene> SceneUnloaded;
         public event Action<Scene> SceneLoaded;
 
+        public bool IsUnloadingScenes => _unloadingScenes.Count > 0;
         public int SceneCount => _loadedScenes.Count;
 
         readonly List<SceneInstance> _unloadingScenes = new List<SceneInstance>();

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
@@ -106,7 +106,7 @@ namespace MyGameDevTools.SceneLoading
 
         public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo)
         {
-            var sceneInstance = GetLastLoadedSceneByInfo(sceneInfo);
+            var sceneInstance = GetLastSceneByInfo(sceneInfo);
             if (!_loadedScenes.Contains(sceneInstance))
                 throw new InvalidOperationException($"Cannot unload the scene \"{sceneInstance.Scene.name}\" that has not been loaded through this {GetType().Name}.");
             if (_unloadingScenes.Contains(sceneInstance))
@@ -117,23 +117,27 @@ namespace MyGameDevTools.SceneLoading
 #if USE_UNITASK
             await operation.ToUniTask();
 #else
-            while (!operation.IsDone)
+            while (operation.IsValid() && !operation.IsDone)
                 await Task.Yield();
 #endif
 
-            if (operation.Status == AsyncOperationStatus.Failed)
-                throw operation.OperationException;
+            Scene unloadedScene;
 
-            var loadedScene = operation.Result.Scene;
+            if (!operation.IsValid())
+                unloadedScene = sceneInstance.Scene;
+            else if (operation.Status == AsyncOperationStatus.Failed)
+                throw operation.OperationException;
+            else
+                unloadedScene = operation.Result.Scene;
 
             _unloadingScenes.Remove(sceneInstance);
             _loadedScenes.Remove(sceneInstance);
             if (_activeSceneInstance.Scene == sceneInstance.Scene)
                 SetActiveScene(GetLastLoadedScene());
 
-            SceneUnloaded?.Invoke(loadedScene);
+            SceneUnloaded?.Invoke(unloadedScene);
 
-            return loadedScene;
+            return unloadedScene;
         }
 
         async ValueTask<Scene> WaitForSceneUnload(SceneInstance sceneInstance)
@@ -161,16 +165,25 @@ namespace MyGameDevTools.SceneLoading
                 throw new Exception($"Unexpected {nameof(ILoadSceneInfo.Reference)} type.");
         }
 
-        SceneInstance GetLastLoadedSceneByInfo(ILoadSceneInfo sceneInfo)
+        SceneInstance GetLastSceneByInfo(ILoadSceneInfo sceneInfo)
         {
             var sceneCount = SceneCount;
-            for (int i = sceneCount - 1; i >= 0; i--)
+            int i;
+            for (i = sceneCount - 1; i >= 0; i--)
             {
                 var sceneInstance = _loadedScenes[i];
                 if (sceneInfo.IsReferenceToScene(sceneInstance.Scene))
                     return sceneInstance;
             }
-            throw new ArgumentException($"Could not find any loaded scene with the provided ILoadSceneInfo: {sceneInfo.Reference}");
+
+            sceneCount = _unloadingScenes.Count;
+            for (i = 0; i < sceneCount; i++)
+            {
+                var sceneInstance = _unloadingScenes[i];
+                if (sceneInfo.IsReferenceToScene(sceneInstance.Scene))
+                    return sceneInstance;
+            }
+            throw new ArgumentException($"Could not find any loaded scene with the provided ILoadSceneInfo: {sceneInfo}");
         }
 
         bool ValidateAssetReference(object reference)

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
@@ -94,5 +94,10 @@ namespace MyGameDevTools.SceneLoading
             else
                 await _manager.UnloadSceneAsync(new LoadSceneInfoScene(currentScene));
         }
+
+        public override string ToString()
+        {
+            return $"Scene Loader [Async] with {_manager.GetType().Name}";
+        }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
@@ -5,7 +5,9 @@
  */
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
@@ -45,10 +47,13 @@ namespace MyGameDevTools.SceneLoading
         async ValueTask<Scene> TransitionWithIntermediateAsync(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo, Scene externalOriginScene)
         {
             var externalOrigin = externalOriginScene.IsValid();
-            var currentScene = externalOrigin ? externalOriginScene : _manager.GetActiveScene();
-            await _manager.LoadSceneAsync(intermediateSceneInfo);
+            
+            var loadingScene = await _manager.LoadSceneAsync(intermediateSceneInfo);
+            intermediateSceneInfo = new LoadSceneInfoScene(loadingScene);
 
-            var loadingBehavior = Object.FindObjectOfType<LoadingBehavior>();
+            var currentScene = externalOrigin ? externalOriginScene : _manager.GetActiveScene();
+
+            var loadingBehavior = Object.FindObjectsOfType<LoadingBehavior>().FirstOrDefault(l => l.gameObject.scene == loadingScene);
             return loadingBehavior
                 ? await TransitionWithIntermediateLoadingAsync(targetSceneInfo, intermediateSceneInfo, loadingBehavior, currentScene, externalOrigin)
                 : await TransitionWithIntermediateNoLoadingAsync(targetSceneInfo, intermediateSceneInfo, currentScene, externalOrigin);
@@ -59,6 +64,9 @@ namespace MyGameDevTools.SceneLoading
             var progress = loadingBehavior.Progress;
             while (progress.State != LoadingState.Loading)
                 await Task.Yield();
+
+            if (!externalOrigin)
+                currentScene = _manager.GetActiveScene();
 
             await UnloadCurrentScene(currentScene, externalOrigin);
 

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
@@ -98,5 +98,10 @@ namespace MyGameDevTools.SceneLoading
             else
                 yield return UnloadRoutine(new LoadSceneInfoScene(currentScene));
         }
+
+        public override string ToString()
+        {
+            return $"Scene Loader [Coroutine] with {_manager.GetType().Name}";
+        }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
@@ -89,6 +89,11 @@ namespace MyGameDevTools.SceneLoading.UniTaskSupport
             else
                 await _manager.UnloadSceneAsync(new LoadSceneInfoScene(currentScene));
         }
+
+        public override string ToString()
+        {
+            return $"Scene Loader [UniTask] with {_manager.GetType().Name}";
+        }
     }
 }
 #endif

--- a/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoAssetReference.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoAssetReference.cs
@@ -33,6 +33,11 @@ namespace MyGameDevTools.SceneLoading
             var sceneInstance = _assetReference.OperationHandle.Convert<SceneInstance>().Result;
             return sceneInstance.Scene == scene;
         }
+
+        public override string ToString()
+        {
+            return $"Scene with asset reference {_assetReference}";
+        }
     }
 }
 #endif

--- a/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoIndex.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoIndex.cs
@@ -31,5 +31,10 @@ namespace MyGameDevTools.SceneLoading
         }
 
         public bool IsReferenceToScene(Scene scene) => scene.buildIndex == _buildIndex;
+
+        public override string ToString()
+        {
+            return $"Scene with index [{_buildIndex}]";
+        }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoName.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoName.cs
@@ -31,5 +31,10 @@ namespace MyGameDevTools.SceneLoading
         }
 
         public bool IsReferenceToScene(Scene scene) => scene.name == _sceneName;
+
+        public override string ToString()
+        {
+            return $"Scene with name \"{_sceneName}\"";
+        }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoScene.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Structs/LoadSceneInfoScene.cs
@@ -23,5 +23,10 @@ namespace MyGameDevTools.SceneLoading
         }
 
         public bool IsReferenceToScene(Scene scene) => scene == _scene;
+
+        public override string ToString()
+        {
+            return $"Scene \"{_scene.name}\" [{_scene.handle}]";
+        }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace MyGameDevTools.SceneLoading
 {
-    public class WaitTask : IEnumerator
+    public readonly struct WaitTask : IEnumerator
     {
         readonly Task _task;
 

--- a/Packages/mygamedevtools-scene-loader/Tests/Runtime/MyGameDevTools.SceneLoading.Tests.asmdef
+++ b/Packages/mygamedevtools-scene-loader/Tests/Runtime/MyGameDevTools.SceneLoading.Tests.asmdef
@@ -7,7 +7,8 @@
         "GUID:9e24947de15b9834991c9d8411ea37cf",
         "GUID:69448af7b92c7f342b298e06a37122aa",
         "GUID:84651a3751eca9349aac36a66bba901b",
-        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
There were some scenarios when the assigned loaded/unloaded scene was incorrect. This led to exceptions being thrown in runtime. The newly added Transition Stress Test covers a reproduction scenario and can be used to ensure it has been fixed.