### PR TITLE
feat: implement IDisposable on ISceneManager and ISceneLoader

### DIFF
--- a/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneLoader.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneLoader.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.SceneManagement;
 
 namespace MyGameDevTools.SceneLoading
@@ -5,7 +6,7 @@ namespace MyGameDevTools.SceneLoading
     /// <summary>
     /// Interface to standardize scene loading operations.
     /// </summary>
-    public interface ISceneLoader
+    public interface ISceneLoader : IDisposable
     {
         /// <summary>
         /// Reference to the <see cref="ISceneManager"/>, responsible for performing the scene loading operations.

--- a/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine.SceneManagement;
 
@@ -10,7 +11,7 @@ namespace MyGameDevTools.SceneLoading
     /// <br/>
     /// A scene manager should only keep track of scenes loaded within its own scope.
     /// </summary>
-    public interface ISceneManager
+    public interface ISceneManager : IDisposable
     {
         /// <summary>
         /// Reports that the active scene has changed, passing the <b>previous</b> and <b>current</b> active scene as parameters.
@@ -53,7 +54,7 @@ namespace MyGameDevTools.SceneLoading
         /// <param name="setIndexActive">Index of the desired scene to set active, based on the <paramref name="sceneInfos"/> array.</param>
         /// <param name="progress">Object to report the loading operations progress to, from 0 to 1.</param>
         /// <returns>A <see cref="System.Threading.Tasks.ValueTask{TResult}"/> with all scenes loaded.</returns>
-        ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null);
+        ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null, CancellationToken token = default);
 
         /// <summary>
         /// Loads a scene referenced by the <paramref name="sceneInfo"/>, optionally enabling it as the active scene.
@@ -63,7 +64,7 @@ namespace MyGameDevTools.SceneLoading
         /// <param name="setActive">Should the loaded scene be enabled as the active scene?</param>
         /// <param name="progress">Object to report the loading operation progress to, from 0 to 1.</param>
         /// <returns>A <see cref="System.Threading.Tasks.ValueTask{TResult}"/> with the loaded scene as the result.</returns>
-        ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null);
+        ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null, CancellationToken token = default);
 
         /// <summary>
         /// Unloads all scenes provided by the <paramref name="sceneInfos"/> array in parallel.
@@ -74,7 +75,7 @@ namespace MyGameDevTools.SceneLoading
         /// <br/>
         /// Note that in some cases, the returned scenes might no longer have a reference to its native representation, hich means its <see cref="Scene.handle"/> will not point anywhere and you won't be able to perform equal comparisons between scenes.
         /// </returns>
-        ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos);
+        ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos, CancellationToken token = default);
 
         /// <summary>
         /// Unloads a scene referenced by the <paramref name="sceneInfo"/>.
@@ -85,7 +86,7 @@ namespace MyGameDevTools.SceneLoading
         /// <br/>
         /// Note that in some cases, the returned scene might no longer have a reference to its native representation, which means its <see cref="Scene.handle"/> will not point anywhere and you won't be able to perform equal comparisons between scenes.
         /// </returns>
-        ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo);
+        ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo, CancellationToken token = default);
 
         /// <summary>
         /// Gets the current active scene in this <see cref="ISceneManager"/> instance.

--- a/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Interfaces/ISceneManager.cs
@@ -54,6 +54,8 @@ namespace MyGameDevTools.SceneLoading
         /// <param name="setIndexActive">Index of the desired scene to set active, based on the <paramref name="sceneInfos"/> array.</param>
         /// <param name="progress">Object to report the loading operations progress to, from 0 to 1.</param>
         /// <returns>A <see cref="System.Threading.Tasks.ValueTask{TResult}"/> with all scenes loaded.</returns>
+        /// <exception cref="ArgumentException">When scene info group is null, empty or the setIndexName is bigger than the scene length.</exception>
+        /// <exception cref="InvalidOperationException">When the provided scene info group fails to produce valid load scene operations.</exception>
         ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null, CancellationToken token = default);
 
         /// <summary>
@@ -64,6 +66,8 @@ namespace MyGameDevTools.SceneLoading
         /// <param name="setActive">Should the loaded scene be enabled as the active scene?</param>
         /// <param name="progress">Object to report the loading operation progress to, from 0 to 1.</param>
         /// <returns>A <see cref="System.Threading.Tasks.ValueTask{TResult}"/> with the loaded scene as the result.</returns>
+        /// <exception cref="ArgumentException">When scene info is null.</exception>
+        /// <exception cref="InvalidOperationException">When the provided scene info fails to produce a valid load scene operation.</exception>
         ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null, CancellationToken token = default);
 
         /// <summary>
@@ -75,6 +79,8 @@ namespace MyGameDevTools.SceneLoading
         /// <br/>
         /// Note that in some cases, the returned scenes might no longer have a reference to its native representation, hich means its <see cref="Scene.handle"/> will not point anywhere and you won't be able to perform equal comparisons between scenes.
         /// </returns>
+        /// <exception cref="ArgumentException">When scene info group is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">When the provided scene info group fails to produce valid unload scene operations.</exception>
         ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos, CancellationToken token = default);
 
         /// <summary>
@@ -86,6 +92,8 @@ namespace MyGameDevTools.SceneLoading
         /// <br/>
         /// Note that in some cases, the returned scene might no longer have a reference to its native representation, which means its <see cref="Scene.handle"/> will not point anywhere and you won't be able to perform equal comparisons between scenes.
         /// </returns>
+        /// <exception cref="ArgumentException">When scene info is null.</exception>
+        /// <exception cref="InvalidOperationException">When the provided scene info fails to produce a valid unload scene operation.</exception>
         ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo, CancellationToken token = default);
 
         /// <summary>

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
@@ -87,8 +87,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 return await LoadScenesAsync_Internal(sceneInfos, setIndexActive, progress, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] LoadScenesAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -107,8 +108,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 loadedScenes = await LoadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] LoadSceneAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -126,8 +128,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 return await UnloadScenesAsync_Internal(sceneInfos, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] UnloadScenesAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -146,8 +149,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 unloadedScenes = await UnloadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] UnloadSceneAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -28,8 +29,18 @@ namespace MyGameDevTools.SceneLoading
 
         readonly List<Scene> _unloadingScenes = new List<Scene>();
         readonly List<Scene> _loadedScenes = new List<Scene>();
+        readonly CancellationTokenSource _lifetimeToken = new CancellationTokenSource();
 
         Scene _activeScene;
+
+        public void Dispose()
+        {
+            _lifetimeToken.Cancel();
+            _lifetimeToken.Dispose();
+
+            _unloadingScenes.Clear();
+            _loadedScenes.Clear();
+        }
 
         public void SetActiveScene(Scene scene)
         {
@@ -69,7 +80,85 @@ namespace MyGameDevTools.SceneLoading
             throw new ArgumentException($"[{GetType().Name}] Could not find any loaded scene with the name '{name}'.", nameof(name));
         }
 
-        public async ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null)
+        public async ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null, CancellationToken token = default)
+        {
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            try
+            {
+                return await LoadScenesAsync_Internal(sceneInfos, setIndexActive, progress, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+        }
+
+        public async ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null, CancellationToken token = default)
+        {
+            sceneInfo = sceneInfo ?? throw new NullReferenceException($"[{GetType().Name}] Provided scene info is null.");
+
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            Scene[] loadedScenes = null;
+            try
+            {
+                loadedScenes = await LoadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+
+            return loadedScenes != null && loadedScenes.Length > 0 ? loadedScenes[0] : default;
+        }
+
+        public async ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos, CancellationToken token = default)
+        {
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            try
+            {
+                return await UnloadScenesAsync_Internal(sceneInfos, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+        }
+
+        public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo, CancellationToken token = default)
+        {
+            sceneInfo = sceneInfo ?? throw new ArgumentNullException(nameof(sceneInfo), $"[{GetType().Name}] Provided scene info is null.");
+
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            Scene[] unloadedScenes = null;
+            try
+            {
+                unloadedScenes = await UnloadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+
+            return unloadedScenes != null && unloadedScenes.Length > 0 ? unloadedScenes[0] : default;
+        }
+
+        async ValueTask<Scene[]> LoadScenesAsync_Internal(ILoadSceneInfo[] sceneInfos, int setIndexActive, IProgress<float> progress, CancellationToken token)
         {
             if (sceneInfos == null || sceneInfos.Length == 0)
                 throw new ArgumentException(nameof(sceneInfos), $"[{GetType().Name}] Provided scene group is null or empty.");
@@ -80,15 +169,17 @@ namespace MyGameDevTools.SceneLoading
             if (operationGroup.Operations.Count == 0)
                 return Array.Empty<Scene>();
 
-            while (!operationGroup.IsDone)
+            while (!operationGroup.IsDone && !token.IsCancellationRequested)
             {
 #if USE_UNITASK
-                await UniTask.Yield();
+                await UniTask.Yield(token);
 #else
                 await Task.Yield();
 #endif
                 progress?.Report(operationGroup.Progress);
             }
+
+            token.ThrowIfCancellationRequested();
 
             var loadedScenes = GetLastUnityLoadedScenesByInfos(sceneInfos, ref setIndexActive);
 
@@ -102,16 +193,7 @@ namespace MyGameDevTools.SceneLoading
             return loadedScenes;
         }
 
-        public async ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null)
-        {
-            sceneInfo = sceneInfo ?? throw new NullReferenceException($"[{GetType().Name}] Provided scene info is null.");
-            var loadedScenes = await LoadScenesAsync(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress);
-            if (loadedScenes.Length == 0)
-                return default;
-            return loadedScenes[0];
-        }
-
-        public async ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos)
+        async ValueTask<Scene[]> UnloadScenesAsync_Internal(ILoadSceneInfo[] sceneInfos, CancellationToken token)
         {
             if (sceneInfos == null || sceneInfos.Length == 0)
                 throw new ArgumentException($"[{GetType().Name}] Provided scene group is null or empty.", nameof(sceneInfos));
@@ -137,12 +219,16 @@ namespace MyGameDevTools.SceneLoading
                 _unloadingScenes.Add(scene);
             }
 
-            while (!operationGroup.IsDone)
+            while (!operationGroup.IsDone && !token.IsCancellationRequested)
+            {
 #if USE_UNITASK
-                await UniTask.Yield();
+                await UniTask.Yield(token);
 #else
                 await Task.Yield();
 #endif
+            }
+
+            token.ThrowIfCancellationRequested();
 
             foreach (var scene in loadedScenes)
             {
@@ -154,7 +240,7 @@ namespace MyGameDevTools.SceneLoading
 
             var tasks = new Task[unloadingLength];
             for (i = 0; i < unloadingLength; i++)
-                tasks[i] = WaitForSceneUnload(unloadingScenes[i]).AsTask();
+                tasks[i] = WaitForSceneUnload(unloadingScenes[i], token).AsTask();
 
             await Task.WhenAll(tasks);
 
@@ -163,23 +249,16 @@ namespace MyGameDevTools.SceneLoading
             return loadedScenes.ToArray();
         }
 
-        public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo)
-        {
-            sceneInfo = sceneInfo ?? throw new ArgumentNullException(nameof(sceneInfo), $"[{GetType().Name}] Provided scene info is null.");
-            var unloadedScenes = await UnloadScenesAsync(new ILoadSceneInfo[] { sceneInfo });
-            if (unloadedScenes.Length == 0)
-                return default;
-            return unloadedScenes[0];
-        }
-
-        async ValueTask<Scene> WaitForSceneUnload(Scene scene)
+        async ValueTask<Scene> WaitForSceneUnload(Scene scene, CancellationToken token)
         {
 #if USE_UNITASK
-            await UniTask.WaitUntil(() => !_unloadingScenes.Contains(scene));
+            await UniTask.WaitUntil(() => !_unloadingScenes.Contains(scene), cancellationToken: token);
 #else
-            while (_unloadingScenes.Contains(scene))
+            while (_unloadingScenes.Contains(scene) && !token.IsCancellationRequested)
                 await Task.Yield();
 #endif
+            token.ThrowIfCancellationRequested();
+
             return scene;
         }
 

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManager.cs
@@ -171,7 +171,7 @@ namespace MyGameDevTools.SceneLoading
 
             var operationGroup = GetLoadSceneOperations(sceneInfos, ref setIndexActive);
             if (operationGroup.Operations.Count == 0)
-                return Array.Empty<Scene>();
+                throw new InvalidOperationException($"[{GetType().Name} Provided scene group was not able to generate any valid load scene operations.");
 
             while (!operationGroup.IsDone && !token.IsCancellationRequested)
             {
@@ -204,7 +204,7 @@ namespace MyGameDevTools.SceneLoading
 
             var loadedScenes = GetLastLoadedScenesByInfos(sceneInfos, out var unloadingIndexes);
             if (loadedScenes.Count == 0)
-                return Array.Empty<Scene>();
+                throw new InvalidOperationException($"[{GetType().Name} Provided scene group was not able to generate any valid unload scene operations.");
 
             int unloadingLength = unloadingIndexes.Length;
             var unloadingScenes = new Scene[unloadingLength];

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
@@ -173,7 +173,7 @@ namespace MyGameDevTools.SceneLoading
 
             var operationGroup = await GetLoadSceneOperations(sceneInfos, setIndexActive, token);
             if (operationGroup.Operations.Count == 0)
-                return Array.Empty<Scene>();
+                throw new InvalidOperationException($"[{GetType().Name} Provided scene group was not able to generate any valid load scene operations.");
 
             while (!operationGroup.IsDone && !token.IsCancellationRequested)
             {
@@ -206,7 +206,7 @@ namespace MyGameDevTools.SceneLoading
 
             var loadedScenes = GetLastLoadedScenesByInfos(sceneInfos, out var unloadingIndexes);
             if (loadedScenes.Count == 0)
-                return Array.Empty<Scene>();
+                throw new InvalidOperationException($"[{GetType().Name} Provided scene group was not able to generate any valid unload scene operations.");
 
             int unloadingLength = unloadingIndexes.Length;
             var unloadingScenes = new SceneInstance[unloadingLength];
@@ -266,8 +266,9 @@ namespace MyGameDevTools.SceneLoading
             while (_unloadingScenes.Contains(sceneInstance) && !token.IsCancellationRequested)
                 await Task.Yield();
 #endif
+            token.ThrowIfCancellationRequested();
 
-            return token.IsCancellationRequested ? default : sceneInstance.Scene;
+            return sceneInstance.Scene;
         }
 
         async ValueTask<AsyncOperationHandleGroup> GetLoadSceneOperations(ILoadSceneInfo[] sceneInfos, int setIndexActive, CancellationToken token)

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
@@ -8,6 +8,7 @@ using Cysharp.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -29,8 +30,18 @@ namespace MyGameDevTools.SceneLoading
 
         readonly List<SceneInstance> _unloadingScenes = new List<SceneInstance>();
         readonly List<SceneInstance> _loadedScenes = new List<SceneInstance>();
+        readonly CancellationTokenSource _lifetimeToken = new CancellationTokenSource();
 
         SceneInstance _activeSceneInstance;
+
+        public void Dispose()
+        {
+            _lifetimeToken.Cancel();
+            _lifetimeToken.Dispose();
+
+            _unloadingScenes.Clear();
+            _loadedScenes.Clear();
+        }
 
         public void SetActiveScene(Scene scene)
         {
@@ -71,26 +82,106 @@ namespace MyGameDevTools.SceneLoading
             throw new ArgumentException($"[{GetType().Name}] Could not find any loaded scene with the name '{name}'.", nameof(name));
         }
 
-        public async ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null)
+        public async ValueTask<Scene[]> LoadScenesAsync(ILoadSceneInfo[] sceneInfos, int setIndexActive = -1, IProgress<float> progress = null, CancellationToken token = default)
+        {
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            try
+            {
+                return await LoadScenesAsync_Internal(sceneInfos, setIndexActive, progress, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+        }
+
+        public async ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null, CancellationToken token = default)
+        {
+            sceneInfo = sceneInfo ?? throw new NullReferenceException($"[{GetType().Name}] Provided scene info is null.");
+
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            Scene[] loadedScenes = null;
+            try
+            {
+                loadedScenes = await LoadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+
+            return loadedScenes != null && loadedScenes.Length > 0 ? loadedScenes[0] : default;
+        }
+
+        public async ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos, CancellationToken token = default)
+        {
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            try
+            {
+                return await UnloadScenesAsync_Internal(sceneInfos, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+        }
+
+        public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo, CancellationToken token = default)
+        {
+            sceneInfo = sceneInfo ?? throw new ArgumentNullException(nameof(sceneInfo), $"[{GetType().Name}] Provided scene info is null.");
+
+            CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeToken.Token, token);
+            Scene[] unloadedScenes = null;
+            try
+            {
+                unloadedScenes = await UnloadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, linkedSource.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            finally
+            {
+                linkedSource.Dispose();
+            }
+
+            return unloadedScenes != null && unloadedScenes.Length > 0 ? unloadedScenes[0] : default;
+        }
+
+        async ValueTask<Scene[]> LoadScenesAsync_Internal(ILoadSceneInfo[] sceneInfos, int setIndexActive, IProgress<float> progress, CancellationToken token = default)
         {
             if (sceneInfos == null || sceneInfos.Length == 0)
                 throw new ArgumentException(nameof(sceneInfos), $"[{GetType().Name}] Provided scene group is null or empty.");
             if (setIndexActive >= sceneInfos.Length)
                 throw new ArgumentException(nameof(setIndexActive), $"[{GetType().Name}] Provided index to set active is bigger than the provided scene group size.");
 
-            var operationGroup = await GetLoadSceneOperations(sceneInfos, setIndexActive);
+            var operationGroup = await GetLoadSceneOperations(sceneInfos, setIndexActive, token);
             if (operationGroup.Operations.Count == 0)
                 return Array.Empty<Scene>();
 
-            while (!operationGroup.IsDone)
+            while (!operationGroup.IsDone && !token.IsCancellationRequested)
             {
 #if USE_UNITASK
-                await UniTask.Yield();
+                await UniTask.Yield(token);
 #else
                 await Task.Yield();
 #endif
                 progress?.Report(operationGroup.Progress);
             }
+
+            token.ThrowIfCancellationRequested();
 
             var loadedScenes = operationGroup.GetResult();
 
@@ -104,16 +195,7 @@ namespace MyGameDevTools.SceneLoading
             return ToSceneArray(loadedScenes);
         }
 
-        public async ValueTask<Scene> LoadSceneAsync(ILoadSceneInfo sceneInfo, bool setActive = false, IProgress<float> progress = null)
-        {
-            sceneInfo = sceneInfo ?? throw new NullReferenceException($"[{GetType().Name}] Provided scene info is null.");
-            var loadedScenes = await LoadScenesAsync(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress);
-            if (loadedScenes.Length == 0)
-                return default;
-            return loadedScenes[0];
-        }
-
-        public async ValueTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneInfos)
+        async ValueTask<Scene[]> UnloadScenesAsync_Internal(ILoadSceneInfo[] sceneInfos, CancellationToken token)
         {
             if (sceneInfos == null || sceneInfos.Length == 0)
                 throw new ArgumentException($"[{GetType().Name}] Provided scene group is null or empty.", nameof(sceneInfos));
@@ -142,11 +224,15 @@ namespace MyGameDevTools.SceneLoading
             var operationGroup = new AsyncOperationHandleGroup(operationList);
 
             while (!operationGroup.IsDone)
+            {
 #if USE_UNITASK
-                await UniTask.Yield();
+                await UniTask.Yield(token);
 #else
                 await Task.Yield();
 #endif
+            }
+
+            token.ThrowIfCancellationRequested();
 
             foreach (var sceneInstance in loadedScenes)
             {
@@ -158,7 +244,7 @@ namespace MyGameDevTools.SceneLoading
 
             var tasks = new Task[unloadingLength];
             for (i = 0; i < unloadingLength; i++)
-                tasks[i] = WaitForSceneUnload(unloadingScenes[i]).AsTask();
+                tasks[i] = WaitForSceneUnload(unloadingScenes[i], token).AsTask();
 
             await Task.WhenAll(tasks);
 
@@ -168,40 +254,60 @@ namespace MyGameDevTools.SceneLoading
             return ToSceneArray(loadedScenes);
         }
 
-        public async ValueTask<Scene> UnloadSceneAsync(ILoadSceneInfo sceneInfo)
-        {
-            sceneInfo = sceneInfo ?? throw new ArgumentNullException(nameof(sceneInfo), $"[{GetType().Name}] Provided scene info is null.");
-            var unloadedScenes = await UnloadScenesAsync(new ILoadSceneInfo[] { sceneInfo });
-            if (unloadedScenes.Length == 0)
-                return default;
-            return unloadedScenes[0];
-        }
-
-        async ValueTask<Scene> WaitForSceneUnload(SceneInstance sceneInstance)
+        async ValueTask<Scene> WaitForSceneUnload(SceneInstance sceneInstance, CancellationToken token)
         {
 #if USE_UNITASK
-            await UniTask.WaitUntil(() => !_unloadingScenes.Contains(sceneInstance));
+            await UniTask.WaitUntil(() => !_unloadingScenes.Contains(sceneInstance), cancellationToken: token);
 #else
-            while (_unloadingScenes.Contains(sceneInstance))
+            while (_unloadingScenes.Contains(sceneInstance) && !token.IsCancellationRequested)
                 await Task.Yield();
 #endif
 
-            return sceneInstance.Scene;
+            return token.IsCancellationRequested ? default : sceneInstance.Scene;
         }
 
-        async ValueTask<AsyncOperationHandleGroup> GetLoadSceneOperations(ILoadSceneInfo[] sceneInfos, int setIndexActive)
+        async ValueTask<AsyncOperationHandleGroup> GetLoadSceneOperations(ILoadSceneInfo[] sceneInfos, int setIndexActive, CancellationToken token)
         {
             var sceneLength = sceneInfos.Length;
             var operationList = new List<AsyncOperationHandle<SceneInstance>>(sceneLength);
             for (int i = 0; i < sceneLength; i++)
             {
-                var operation = await GetLoadSceneOperation(sceneInfos[i]);
+                var operation = await GetLoadSceneOperation(sceneInfos[i], token);
                 if (operation.IsValid())
                     operationList.Add(operation);
                 else if (i == setIndexActive)
                     setIndexActive = -1;
             }
             return new AsyncOperationHandleGroup(operationList, setIndexActive);
+        }
+
+        async ValueTask<AsyncOperationHandle<SceneInstance>> GetLoadSceneOperation(ILoadSceneInfo sceneInfo, CancellationToken token)
+        {
+            if (sceneInfo.Reference is AssetReference assetReference)
+                return assetReference.LoadSceneAsync(LoadSceneMode.Additive);
+            else if (sceneInfo.Reference is string name)
+            {
+                if (await ValidateAssetReference(name, token))
+                    return Addressables.LoadSceneAsync(name, LoadSceneMode.Additive);
+                else
+                {
+                    Debug.LogWarning($"[{GetType().Name}] Scene '{name}' couldn't be loaded because its address found no Addressable Assets.");
+                    return default;
+                }
+            }
+
+            Debug.LogWarning($"[{GetType().Name}] Unexpected {nameof(ILoadSceneInfo.Reference)} type: {sceneInfo.Reference}");
+            return default;
+        }
+
+        async ValueTask<bool> ValidateAssetReference(object reference, CancellationToken token)
+        {
+            var operation = Addressables.LoadResourceLocationsAsync(reference);
+            while (!operation.IsDone && !token.IsCancellationRequested)
+                await Task.Yield();
+
+            token.ThrowIfCancellationRequested();
+            return operation.Result.Count > 0;
         }
 
         IList<SceneInstance> GetLastLoadedScenesByInfos(ILoadSceneInfo[] sceneInfos, out int[] unloadingIndexes)
@@ -259,25 +365,6 @@ namespace MyGameDevTools.SceneLoading
             return sceneArray;
         }
 
-        async ValueTask<AsyncOperationHandle<SceneInstance>> GetLoadSceneOperation(ILoadSceneInfo sceneInfo)
-        {
-            if (sceneInfo.Reference is AssetReference assetReference)
-                return assetReference.LoadSceneAsync(LoadSceneMode.Additive);
-            else if (sceneInfo.Reference is string name)
-            {
-                if (await ValidateAssetReference(name))
-                    return Addressables.LoadSceneAsync(name, LoadSceneMode.Additive);
-                else
-                {
-                    Debug.LogWarning($"[{GetType().Name}] Scene '{name}' couldn't be loaded because its address found no Addressable Assets.");
-                    return default;
-                }
-            }
-
-            Debug.LogWarning($"[{GetType().Name}] Unexpected {nameof(ILoadSceneInfo.Reference)} type: {sceneInfo.Reference}");
-            return default;
-        }
-
         bool TryGetInstanceFromScene(Scene scene, out SceneInstance sceneInstance)
         {
             foreach (var instance in _loadedScenes)
@@ -289,19 +376,6 @@ namespace MyGameDevTools.SceneLoading
 
             sceneInstance = default;
             return false;
-        }
-
-        async ValueTask<bool> ValidateAssetReference(object reference)
-        {
-            var operation = Addressables.LoadResourceLocationsAsync(reference);
-#if USE_UNITASK
-            await operation;
-#else
-            while (!operation.IsDone)
-                await Task.Yield();
-#endif
-
-            return operation.Result.Count > 0;
         }
     }
 }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Managers/SceneManagerAddressable.cs
@@ -89,8 +89,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 return await LoadScenesAsync_Internal(sceneInfos, setIndexActive, progress, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] LoadScenesAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -109,8 +110,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 loadedScenes = await LoadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, setActive ? 0 : -1, progress, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] LoadSceneAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -128,8 +130,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 return await UnloadScenesAsync_Internal(sceneInfos, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] UnloadScenesAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally
@@ -148,8 +151,9 @@ namespace MyGameDevTools.SceneLoading
             {
                 unloadedScenes = await UnloadScenesAsync_Internal(new ILoadSceneInfo[] { sceneInfo }, linkedSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException cancelException)
             {
+                Debug.LogWarningFormat("[{0}] UnloadSceneAsync was canceled. Exception:\n{1}", GetType().Name, cancelException);
                 throw;
             }
             finally

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
@@ -63,6 +63,9 @@ namespace MyGameDevTools.SceneLoading
             var externalOrigin = externalOriginScene.IsValid();
             
             var loadingScene = await _manager.LoadSceneAsync(intermediateSceneInfo);
+            if (!loadingScene.IsValid())
+                return Array.Empty<Scene>();
+
             intermediateSceneInfo = new LoadSceneInfoScene(loadingScene);
 
             var currentScene = externalOrigin ? externalOriginScene : _manager.GetActiveScene();
@@ -114,7 +117,7 @@ namespace MyGameDevTools.SceneLoading
             if (externalOrigin)
             {
                 var operation = UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(currentScene);
-                while (!operation.isDone)
+                while (operation != null && !operation.isDone)
                     await Task.Yield();
             }
             else

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderAsync.cs
@@ -17,6 +17,11 @@ namespace MyGameDevTools.SceneLoading
             _manager = manager ?? throw new ArgumentNullException("Cannot create a scene loader with a null Scene Manager");
         }
 
+        public void Dispose()
+        {
+            _manager.Dispose();
+        }
+
         public void TransitionToScenes(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null, Scene externalOriginScene = default) => TransitionToScenesAsync(targetScenes, setIndexActive, intermediateSceneInfo, externalOriginScene);
 
         public void TransitionToScene(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = default, Scene externalOriginScene = default) => _ = TransitionToSceneAsync(targetSceneInfo, intermediateSceneInfo, externalOriginScene);

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
@@ -191,7 +189,7 @@ namespace MyGameDevTools.SceneLoading
 
                 if (_externalOrigin)
                 {
-                    return !_unloadOperation.isDone;
+                    return _unloadOperation != null && !_unloadOperation.isDone;
                 }
                 else
                 {

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Linq;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
@@ -85,7 +86,7 @@ namespace MyGameDevTools.SceneLoading
             var externalOrigin = externalOriginScene.IsValid();
             
             var task = _manager.LoadSceneAsync(intermediateSceneInfo).AsTask();
-            yield return new WaitTask(task);
+            yield return new WaitTask(task, false);
             if (task.IsCanceled)
                 yield break;
 
@@ -119,7 +120,7 @@ namespace MyGameDevTools.SceneLoading
 
             var loadWaitTask = GetLoadScenesWaitTask(targetScenes, setIndexActive, null);
             yield return loadWaitTask;
-            if (loadWaitTask.IsTaskCanceled)
+            if (loadWaitTask.Task.IsCanceled)
                 yield break;
 
             progress.SetState(LoadingState.TargetSceneLoaded);
@@ -138,7 +139,7 @@ namespace MyGameDevTools.SceneLoading
 
             var loadWaitTask = GetLoadScenesWaitTask(targetScenes, setIndexActive, null);
             yield return loadWaitTask;
-            if (loadWaitTask.IsTaskCanceled)
+            if (loadWaitTask.Task.IsCanceled)
                 yield break;
             UnloadSceneAsync(intermediateSceneInfo);
         }
@@ -151,7 +152,7 @@ namespace MyGameDevTools.SceneLoading
         readonly struct WaitCurrentSceneUnload : IEnumerator
         {
             public object Current => null;
-            public bool IsTaskCanceled => !_externalOrigin && _unloadWaitTask.IsTaskCanceled;
+            public bool IsTaskCanceled => !_externalOrigin && _unloadWaitTask.Task.IsCanceled;
 
             readonly AsyncOperation _unloadOperation;
             readonly WaitTask _unloadWaitTask;

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
@@ -2,6 +2,7 @@
 using Cysharp.Threading.Tasks;
 using System;
 using System.Linq;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
@@ -64,6 +65,9 @@ namespace MyGameDevTools.SceneLoading.UniTaskSupport
             var externalOrigin = externalOriginScene.IsValid();
 
             var loadingScene = await _manager.LoadSceneAsync(intermediateSceneInfo);
+            if (!loadingScene.IsValid())
+                return Array.Empty<Scene>();
+
             intermediateSceneInfo = new LoadSceneInfoScene(loadingScene);
 
             var currentScene = externalOrigin ? externalOriginScene : _manager.GetActiveScene();
@@ -111,11 +115,11 @@ namespace MyGameDevTools.SceneLoading.UniTaskSupport
                 return;
 
             if (externalOrigin)
-#if UNITY_2023_2_OR_NEWER
-                await UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(currentScene).ToUniTask();
-#else
-                await UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(currentScene);
-#endif
+            {
+                AsyncOperation operation = UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(currentScene);
+                if (operation != null)
+                    await operation;
+            }
             else
                 await _manager.UnloadSceneAsync(new LoadSceneInfoScene(currentScene));
         }

--- a/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
@@ -18,6 +18,11 @@ namespace MyGameDevTools.SceneLoading.UniTaskSupport
             _manager = manager ?? throw new ArgumentNullException("Cannot create a scene loader with a null Scene Manager");
         }
 
+        public void Dispose()
+        {
+            _manager.Dispose();
+        }
+
         public void TransitionToScenes(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null, Scene externalOriginScene = default) => TransitionToScenesAsync(targetScenes, setIndexActive, intermediateSceneInfo, externalOriginScene);
 
         public void TransitionToScene(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = default, Scene externalOriginScene = default) => TransitionToSceneAsync(targetSceneInfo, intermediateSceneInfo, externalOriginScene).Forget();

--- a/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Threading.Tasks;
 
@@ -9,6 +8,7 @@ namespace MyGameDevTools.SceneLoading
         readonly Task _task;
 
         public object Current => null;
+        public bool IsTaskCanceled => _task.IsCanceled;
 
         public WaitTask(Task task)
         {

--- a/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Threading.Tasks;
 
@@ -5,22 +6,24 @@ namespace MyGameDevTools.SceneLoading
 {
     public readonly struct WaitTask : IEnumerator
     {
-        readonly Task _task;
-
         public object Current => null;
-        public bool IsTaskCanceled => _task.IsCanceled;
 
-        public WaitTask(Task task)
+        public readonly Task Task;
+
+        readonly bool _throwOnException;
+
+        public WaitTask(Task task, bool throwOnException = true)
         {
-            _task = task;
+            Task = task;
+            _throwOnException = throwOnException;
         }
 
         public bool MoveNext()
         {
-            if (_task.IsFaulted)
-                throw _task.Exception;
+            if (_throwOnException && Task.IsFaulted)
+                throw Task.Exception;
 
-            return !_task.IsCompleted && !_task.IsCanceled;
+            return !Task.IsCompleted && !Task.IsCanceled && !Task.IsFaulted;
         }
 
         public void Reset() { }

--- a/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
+++ b/Packages/mygamedevtools-scene-loader/Runtime/Utilities/WaitTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Threading.Tasks;
 
@@ -19,7 +20,7 @@ namespace MyGameDevTools.SceneLoading
             if (_task.IsFaulted)
                 throw _task.Exception;
 
-            return !_task.IsCompleted;
+            return !_task.IsCompleted && !_task.IsCanceled;
         }
 
         public void Reset() { }

--- a/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneLoaderTests.cs
+++ b/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneLoaderTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -188,11 +187,12 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             var watch = new Stopwatch();
             watch.Start();
-            yield return new WaitUntil(() => unloadedScene.IsValid() && !unloadedScene.isLoaded || watch.ElapsedMilliseconds > _defaultTimeout);
+            yield return new WaitUntil(() => unloadedScene.handle != 0 && !unloadedScene.isLoaded || watch.ElapsedMilliseconds > _defaultTimeout);
             watch.Stop();
 
             sceneLoader.Manager.SceneUnloaded -= sceneUnloaded;
 
+            Assert.Less(watch.ElapsedMilliseconds, _defaultTimeout);
             Assert.AreEqual(loadedScene, unloadedScene);
             Assert.IsFalse(unloadedScene.isLoaded);
 
@@ -340,27 +340,30 @@ namespace MyGameDevTools.SceneLoading.Tests
             }
         }
 
-        [Test]
-        public void Dispose_Simple([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
+        [UnityTest]
+        public IEnumerator Dispose_Simple([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
         {
             ISceneLoader loader = loaderCreateFunc();
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
-        [Test]
-        public void Dispose_DuringLoadScene([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
+        [UnityTest]
+        public IEnumerator Dispose_DuringLoadScene([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
         {
             ISceneLoader loader = loaderCreateFunc();
             loader.LoadScene(new LoadSceneInfoName(SceneBuilder.SceneNames[1]));
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
-        [Test]
-        public void Dispose_DuringLoadScenes([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
+        [UnityTest]
+        public IEnumerator Dispose_DuringLoadScenes([ValueSource(nameof(_sceneLoaderCreateFuncs))] Func<ISceneLoader> loaderCreateFunc)
         {
             ISceneLoader loader = loaderCreateFunc();
             loader.LoadScenes(_targetSceneGroups[0]);
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
         [UnityTest]
@@ -371,6 +374,7 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             loader.UnloadScene(new LoadSceneInfoScene(loader.Manager.GetLastLoadedScene()));
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
         [UnityTest]
@@ -388,6 +392,7 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             loader.UnloadScenes(targetScenes);
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
         [UnityTest]
@@ -399,6 +404,7 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             loader.TransitionToScene(targetScene, loadingScene);
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
         [UnityTest]
@@ -410,6 +416,7 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             loader.TransitionToScenes(targetScenes, 0, loadingScene);
             Assert.DoesNotThrow(loader.Dispose);
+            yield return null;
         }
 
         /// <summary>

--- a/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneManagerTests.cs
+++ b/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneManagerTests.cs
@@ -427,7 +427,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Dispose_AfterLoadScene([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
+        public IEnumerator Dispose_DuringLoadScene([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
         {
             ISceneManager manager = managerCreateFunc();
             Task task = manager.LoadSceneAsync(new LoadSceneInfoName(SceneBuilder.SceneNames[1])).AsTask();
@@ -437,7 +437,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Dispose_AfterLoadScenes([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
+        public IEnumerator Dispose_DuringLoadScenes([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
         {
             ISceneManager manager = managerCreateFunc();
             Task task = manager.LoadScenesAsync(_loadSceneInfos_multiple[0]).AsTask();
@@ -447,7 +447,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Dipose_AfterUnloadScene([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
+        public IEnumerator Dipose_DuringUnloadScene([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
         {
             ISceneManager manager = managerCreateFunc();
             ILoadSceneInfo sceneInfo = new LoadSceneInfoName(SceneBuilder.SceneNames[1]);
@@ -461,7 +461,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Dipose_AfterUnloadScenes([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
+        public IEnumerator Dipose_DuringUnloadScenes([ValueSource(nameof(_sceneManagerCreateFuncs))] Func<ISceneManager> managerCreateFunc)
         {
             ISceneManager manager = managerCreateFunc();
             Task task = manager.LoadScenesAsync(_loadSceneInfos_multiple[0]).AsTask();
@@ -474,7 +474,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Cancellation_AfterLoadScene([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
+        public IEnumerator Cancellation_DuringLoadScene([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
         {
             CancellationTokenSource tokenSource = new();
             Task task = manager.LoadSceneAsync(new LoadSceneInfoName(SceneBuilder.SceneNames[1]), token: tokenSource.Token).AsTask();
@@ -485,7 +485,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Cancellation_AfterLoadScenes([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
+        public IEnumerator Cancellation_DuringLoadScenes([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
         {
             CancellationTokenSource tokenSource = new();
             Task task = manager.LoadScenesAsync(_loadSceneInfos_multiple[0], token: tokenSource.Token).AsTask();
@@ -496,7 +496,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Cancellation_AfterUnloadScene([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
+        public IEnumerator Cancellation_DuringUnloadScene([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
         {
             CancellationTokenSource tokenSource = new();
             ILoadSceneInfo sceneInfo = new LoadSceneInfoName(SceneBuilder.SceneNames[1]);
@@ -511,7 +511,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
-        public IEnumerator Cancellation_AfterUnloadScenes([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
+        public IEnumerator Cancellation_DuringUnloadScenes([ValueSource(nameof(_sceneManagers))] ISceneManager manager)
         {
             CancellationTokenSource tokenSource = new();
             Task task = manager.LoadScenesAsync(_loadSceneInfos_multiple[0]).AsTask();

--- a/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneManagerTests.cs
+++ b/Packages/mygamedevtools-scene-loader/Tests/Runtime/SceneManagerTests.cs
@@ -280,7 +280,7 @@ namespace MyGameDevTools.SceneLoading.Tests
             if (manager is SceneManager)
                 LogAssert.Expect(LogType.Error, new Regex("'not-a-real-scene' couldn't be loaded"));
             var wait = new WaitTask(manager.LoadSceneAsync(new LoadSceneInfoName(sceneName), false).AsTask());
-            wait.MoveNext();
+            Assert.Throws<AggregateException>(() => wait.MoveNext());
         }
 
         [UnityTest]
@@ -358,7 +358,7 @@ namespace MyGameDevTools.SceneLoading.Tests
             var sceneName = "not-a-real-scene";
             LogAssert.Expect(LogType.Warning, new Regex("Some of the scenes could not be found loaded"));
             var wait = new WaitTask(manager.UnloadSceneAsync(new LoadSceneInfoName(sceneName)).AsTask());
-            wait.MoveNext();
+            Assert.Throws<AggregateException>(() => wait.MoveNext());
         }
 
         [UnityTest]

--- a/Packages/mygamedevtools-scene-loader/Tests/Runtime/Utilities/SceneLoaderTestUtilities.cs
+++ b/Packages/mygamedevtools-scene-loader/Tests/Runtime/Utilities/SceneLoaderTestUtilities.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections;
 using NUnit.Framework;
+using UnitySceneManager = UnityEngine.SceneManagement.SceneManager;
 
 namespace MyGameDevTools.SceneLoading.Tests
 {
@@ -20,6 +21,14 @@ namespace MyGameDevTools.SceneLoading.Tests
 
             Assert.Zero(sceneManager.SceneCount);
             Assert.False(sceneManager.GetActiveScene().IsValid());
+        }
+
+        public static IEnumerator UnloadRemainingScenes()
+        {
+            while (UnitySceneManager.loadedSceneCount > 1)
+            {
+                yield return UnitySceneManager.UnloadSceneAsync(UnitySceneManager.GetSceneAt(UnitySceneManager.loadedSceneCount - 1));
+            }
         }
     }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -54,15 +54,15 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.ide.visualstudio": "2.0.22",
-        "com.unity.ide.rider": "3.0.26",
+        "com.unity.ide.rider": "3.0.27",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.performance.profile-analyzer": "1.2.2",
         "com.unity.test-framework": "1.3.9",
-        "com.unity.testtools.codecoverage": "1.2.4"
+        "com.unity.testtools.codecoverage": "1.2.5"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.26",
+      "version": "3.0.27",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -112,7 +112,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2023.2.3f1
-m_EditorVersionWithRevision: 2023.2.3f1 (21747dafc6ee)
+m_EditorVersion: 2023.2.7f1
+m_EditorVersionWithRevision: 2023.2.7f1 (0a9195b3d453)


### PR DESCRIPTION
Adds the `IDisposable` implementation for the `ISceneManager` and `ISceneLoader` interfaces, forcing all Scene Managers and Scene Loaders to implement the `Dispose` method. This can minimize issues for Application Quit scenarios, for example.

Adds the option to "cancel" the `ISceneManager` methods. It exists only as a safety measure to cancel all inner operations when the Scene Manager gets disposed. Manually canceling the Scene Manager methods does not cancel the actual loading/unloading of scenes, since that's handled through the Unity Scene Manager and there are no ways to cancel its methods.

Tests have been added to ensure the disposal of Scene Manager and Scene Loader instances do not break any behavior and are correctly treated by the system.