### PR TITLE
fix: scene linking for scenes loaded by path

### DIFF
--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Structs/LoadSceneInfoName.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Structs/LoadSceneInfoName.cs
@@ -10,27 +10,27 @@ namespace MyGameDevTools.SceneLoading
     {
         public readonly LoadSceneInfoType Type => LoadSceneInfoType.Name;
 
-        public readonly object Reference => _sceneName;
+        public readonly object Reference => _sceneNameOrPath;
 
-        readonly string _sceneName;
+        readonly string _sceneNameOrPath;
 
         /// <summary>
-        /// Creates a new <see cref="ILoadSceneInfo"/> based on the scene's name.
+        /// Creates a new <see cref="ILoadSceneInfo"/> based on the scene's name or path.
         /// The scene must be added to the Build Settings in order to be loaded.
         /// </summary>
-        /// <param name="sceneName">`The scene's asset name, as displayed in the Build Settings window.</param>
-        public LoadSceneInfoName(string sceneName)
+        /// <param name="sceneNameOrPath">`The scene's asset name or path, as displayed in the Build Settings window.</param>
+        public LoadSceneInfoName(string sceneNameOrPath)
         {
-            if (string.IsNullOrWhiteSpace(sceneName))
-                throw new ArgumentException("Cannot create a LoadSceneInfoName from an empty string.", nameof(sceneName));
-            _sceneName = sceneName;
+            if (string.IsNullOrWhiteSpace(sceneNameOrPath))
+                throw new ArgumentException("Cannot create a LoadSceneInfoName from an empty string.", nameof(sceneNameOrPath));
+            _sceneNameOrPath = sceneNameOrPath;
         }
 
-        public bool CanBeReferenceToScene(Scene scene) => scene.name == _sceneName;
+        public bool CanBeReferenceToScene(Scene scene) => scene.name == _sceneNameOrPath || scene.path == _sceneNameOrPath;
 
         public override string ToString()
         {
-            return $"Scene with name '{_sceneName}'";
+            return $"Scene with name '{_sceneNameOrPath}'";
         }
 
         public bool Equals(ILoadSceneInfo other)

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Structs/LoadSceneInfoName.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Structs/LoadSceneInfoName.cs
@@ -30,7 +30,7 @@ namespace MyGameDevTools.SceneLoading
 
         public override string ToString()
         {
-            return $"Scene with name '{_sceneNameOrPath}'";
+            return $"Scene with name/path '{_sceneNameOrPath}'";
         }
 
         public bool Equals(ILoadSceneInfo other)

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Utilities/SceneDataUtilities.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Utilities/SceneDataUtilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnitySceneManager = UnityEngine.SceneManagement.SceneManager;
@@ -69,7 +70,7 @@ namespace MyGameDevTools.SceneLoading
 
             if (unmatchedSceneDatas.Count > 0)
             {
-                Debug.LogError($"Unable to link all scene datas to loaded scenes. Linked {sceneDataCount - unmatchedSceneDatas.Count}/{sceneDataCount}.");
+                throw new Exception($"Unable to link all scene datas to loaded scenes. Linked {sceneDataCount - unmatchedSceneDatas.Count}/{sceneDataCount}.");
             }
         }
 

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/Utilities/SceneBuilder.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/Utilities/SceneBuilder.cs
@@ -11,6 +11,13 @@ namespace MyGameDevTools.SceneLoading.Tests
     public static class SceneBuilder
     {
         public static readonly string[] SceneNames = new string[] { "loading", "sceneA", "sceneB", "sceneC" };
+        public static readonly string[] ScenePaths = new string[]
+        {
+            SceneTestEnvironment.ScenePathBase + "/" + SceneNames[0] + ".unity",
+            SceneTestEnvironment.ScenePathBase + "/" + SceneNames[1] + ".unity",
+            SceneTestEnvironment.ScenePathBase + "/" + SceneNames[2] + ".unity",
+            SceneTestEnvironment.ScenePathBase + "/" + SceneNames[3] + ".unity",
+        };
 
 #if UNITY_EDITOR
         static readonly string _scenePathFormat = "/{0}.unity";

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/Utilities/SceneTestEnvironment.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/Utilities/SceneTestEnvironment.cs
@@ -19,6 +19,7 @@ namespace MyGameDevTools.SceneLoading.Tests
 {
     public class SceneTestEnvironment : IPrebuildSetup, IPostBuildCleanup
     {
+        public const string ScenePathBase = "Assets/_test";
         public const int DefaultTimeout = 3000;
 
         public static readonly ILoadSceneInfo[][] MultipleLoadSceneInfoList = new ILoadSceneInfo[][]
@@ -31,6 +32,7 @@ namespace MyGameDevTools.SceneLoading.Tests
                 new LoadSceneInfoAddress(SceneBuilder.SceneNames[2]),
                 new LoadSceneInfoAddress(SceneBuilder.SceneNames[3]),
 #endif
+                new LoadSceneInfoName(SceneBuilder.ScenePaths[3])
             },
             // This list of scenes expects two load scene infos that point to the same source scene,
             // and validates whether that causes any issues when linking to the target loaded scene.
@@ -38,6 +40,7 @@ namespace MyGameDevTools.SceneLoading.Tests
             {
                 new LoadSceneInfoIndex(1),
                 new LoadSceneInfoName(SceneBuilder.SceneNames[1]),
+                new LoadSceneInfoName(SceneBuilder.ScenePaths[1]),
 #if ENABLE_ADDRESSABLES
                 // Since we can't test statically with AssetReference, we should at least validate
                 // that two AsyncOperations with the same addressable source do not cause issues.
@@ -50,6 +53,7 @@ namespace MyGameDevTools.SceneLoading.Tests
         public static readonly ILoadSceneInfo[] SingleLoadSceneInfoList = new ILoadSceneInfo[]
         {
             new LoadSceneInfoName(SceneBuilder.SceneNames[1]),
+            new LoadSceneInfoName(SceneBuilder.ScenePaths[1]),
             new LoadSceneInfoIndex(1),
 #if ENABLE_ADDRESSABLES
             new LoadSceneInfoAddress(SceneBuilder.SceneNames[1]),
@@ -62,7 +66,6 @@ namespace MyGameDevTools.SceneLoading.Tests
         };
 
 #if UNITY_EDITOR
-        const string _scenePathBase = "Assets/_test";
 #if ENABLE_ADDRESSABLES
         const string _addressableScenePathBase = "Assets/_addressables-test";
         const string _sceneReferencePath = _addressableScenePathBase + "/sceneReference.asset";
@@ -75,7 +78,7 @@ namespace MyGameDevTools.SceneLoading.Tests
             int sceneCount = SceneBuilder.SceneNames.Length;
             List<EditorBuildSettingsScene> buildScenes = new(sceneCount);
 
-            if (!SceneBuilder.TryBuildScenes(_scenePathBase, (i, s, p) => buildScenes.Add(new EditorBuildSettingsScene(p, true))))
+            if (!SceneBuilder.TryBuildScenes(ScenePathBase, (i, s, p) => buildScenes.Add(new EditorBuildSettingsScene(p, true))))
                 return;
 
             Debug.Log("Adding test scenes to build settings:\n" + string.Join("\n", buildScenes.Select(scene => scene.path)));
@@ -104,12 +107,12 @@ namespace MyGameDevTools.SceneLoading.Tests
         public void Cleanup()
         {
 #if UNITY_EDITOR
-            EditorBuildSettings.scenes = EditorBuildSettings.scenes.Where(scene => !scene.path.StartsWith(_scenePathBase)).ToArray();
+            EditorBuildSettings.scenes = EditorBuildSettings.scenes.Where(scene => !scene.path.StartsWith(ScenePathBase)).ToArray();
 
-            if (!Directory.Exists(_scenePathBase))
+            if (!Directory.Exists(ScenePathBase))
                 return;
 
-            AssetDatabase.DeleteAsset(_scenePathBase);
+            AssetDatabase.DeleteAsset(ScenePathBase);
             AssetDatabase.Refresh();
 
 #if ENABLE_ADDRESSABLES


### PR DESCRIPTION
Fixes #40.

In version `2.x`, the standard (non-addressable) scenes were never linked to their load scene info. In version `3.x` the package introduced scene linking, but did not account for scenes loaded by path.

This PR includes support for scene linking when loading scenes by path and includes scenes loaded by path in all existing tests.