### PR TITLE
feat: add new scene transition methods

### DIFF
--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneLoader.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneLoader.cs
@@ -15,7 +15,7 @@ namespace MyGameDevTools.SceneLoading
         ISceneManager Manager { get; }
 
         /// <summary>
-        /// Triggers a transition to a group of scens.
+        /// Triggers a transition to a group of scenes from the active scene.
         /// It will transition from the current active scene (<see cref="ISceneManager.GetActiveScene()"/>)
         /// to a group of scenes (<paramref name="targetScenes"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
         /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
@@ -39,7 +39,7 @@ namespace MyGameDevTools.SceneLoading
         void TransitionToScenes(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null);
 
         /// <summary>
-        /// Triggers a scene transition.
+        /// Triggers a transition to the target scene from the active scene.
         /// It will transition from the current active scene (<see cref="ISceneManager.GetActiveScene()"/>)
         /// to the target scene (<paramref name="targetSceneInfo"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
         /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
@@ -58,6 +58,105 @@ namespace MyGameDevTools.SceneLoading
         /// If null, the transition will not have an intermediate loading scene.
         /// </param>
         void TransitionToScene(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = null);
+
+        /// <summary>
+        /// Triggers a transition to a group of scenes from another group of scenes.
+        /// It will transition from the provided group of scenes (<paramref name="fromScenes"/>)
+        /// to a group of scenes (<paramref name="targetScenes"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
+        /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
+        /// The complete transition flow is:
+        /// <br/><br/>
+        /// 1. Load the intermediate scene (if provided).<br/>
+        /// 2. Unload all provided scenes.<br/>
+        /// 3. Load all target scenes.<br/>
+        /// 4. Unload the intermediate scene (if provided).<br/>
+        /// </summary>
+        /// <param name="targetScenes">
+        /// A reference to all scenes that will be transitioned to.
+        /// </param>
+        /// <param name="fromScenes">
+        /// A reference to all scenes that will be unloaded in the transition.
+        /// </param>
+        /// <param name="setIndexActive">
+        /// Index of the scene in the <paramref name="targetScenes"/> to be set as the active scene.
+        /// </param>
+        /// <param name="intermediateSceneInfo">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        void TransitionToScenesFromScenes(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null);
+
+        /// <summary>
+        /// Triggers a transition to the target scene from a group of scens.
+        /// It will transition from the provided group of scenes (<paramref name="fromScenes"/>)
+        /// to the target scene (<paramref name="targetSceneInfo"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
+        /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
+        /// The complete transition flow is:
+        /// <br/><br/>
+        /// 1. Load the intermediate scene (if provided).<br/>
+        /// 2. Unload all provided scenes.<br/>
+        /// 3. Load the target scene.<br/>
+        /// 4. Unload the intermediate scene (if provided).<br/>
+        /// </summary>
+        /// <param name="targetSceneInfo">
+        /// A reference to the scene that's going to be transitioned to.
+        /// </param>
+        /// <param name="fromScenes">
+        /// A reference to all scenes that will be unloaded in the transition.
+        /// </param>
+        /// <param name="intermediateSceneInfo">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        void TransitionToSceneFromScenes(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneInfo = null);
+
+        /// <summary>
+        /// Triggers a transition to a group of scenes from all loaded scenes.
+        /// It will transition from all loaded scenes
+        /// to a group of scenes (<paramref name="targetScenes"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
+        /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
+        /// The complete transition flow is:
+        /// <br/><br/>
+        /// 1. Load the intermediate scene (if provided).<br/>
+        /// 2. Unload all loaded scenes.<br/>
+        /// 3. Load all target scenes.<br/>
+        /// 4. Unload the intermediate scene (if provided).<br/>
+        /// </summary>
+        /// <param name="targetScenes">
+        /// A reference to all scenes that will be transitioned to.
+        /// </param>
+        /// <param name="setIndexActive">
+        /// Index of the scene in the <paramref name="targetScenes"/> to be set as the active scene.
+        /// </param>
+        /// <param name="intermediateSceneInfo">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        void TransitionToScenesFromAll(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null);
+
+        /// <summary>
+        /// Triggers a transition to the target scene from all loaded scenes.
+        /// It will transition from the provided group of scenes (<paramref name="fromScenes"/>)
+        /// to the target scene (<paramref name="targetSceneInfo"/>), with an optional intermediate loading scene (<paramref name="intermediateSceneInfo"/>).
+        /// If the <paramref name="intermediateSceneInfo"/> is not set, the transition will have no intermediate loading scene and will instead simply load the target scene directly.
+        /// The complete transition flow is:
+        /// <br/><br/>
+        /// 1. Load the intermediate scene (if provided).<br/>
+        /// 2. Unload all provided scenes.<br/>
+        /// 3. Load the target scene.<br/>
+        /// 4. Unload the intermediate scene (if provided).<br/>
+        /// </summary>
+        /// <param name="targetSceneInfo">
+        /// A reference to the scene that's going to be transitioned to.
+        /// </param>
+        /// <param name="fromScenes">
+        /// A reference to all scenes that will be unloaded in the transition.
+        /// </param>
+        /// <param name="intermediateSceneInfo">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        void TransitionToSceneFromAll(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = null);
 
         /// <summary>
         /// Unloads all the scenes from the current scene stack.

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneLoaderAsync.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneLoaderAsync.cs
@@ -50,6 +50,78 @@ namespace MyGameDevTools.SceneLoading
         TAsyncScene TransitionToSceneAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = default);
 
         /// <summary>
+        /// Async version of the <see cref="ISceneLoader.TransitionToScenesFromScenes(ILoadSceneInfo[], ILoadSceneInfo[], int, ILoadSceneInfo)"/>
+        /// </summary>
+        /// <param name="targetScenes">
+        /// A reference to all scenes that will be transitioned to.
+        /// </param>
+        /// <param name="fromScenes">
+        /// A reference to all scenes that will be unloaded in the transition.
+        /// </param>
+        /// <param name="setIndexActive">
+        /// Index of the scene in the <paramref name="targetScenes"/> to be set as the active scene.
+        /// </param>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <returns>
+        /// The transition operation.
+        /// </returns>
+        TAsyncSceneArray TransitionToScenesFromScenesAsync(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = default);
+
+        /// <summary>
+        /// Async version of the <see cref="ISceneLoader.TransitionToSceneFromScenes(ILoadSceneInfo, ILoadSceneInfo[], ILoadSceneInfo)"/>
+        /// </summary>
+        /// <param name="targetSceneReference">
+        /// A reference to the scene that's going to be transitioned to.
+        /// </param>
+        /// <param name="fromScenes">
+        /// A reference to all scenes that will be unloaded in the transition.
+        /// </param>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <returns>
+        /// The transition operation.
+        /// </returns>
+        TAsyncScene TransitionToSceneFromScenesAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneReference = default);
+
+        /// <summary>
+        /// Async version of the <see cref="ISceneLoader.TransitionToScenesFromAll(ILoadSceneInfo[], int, ILoadSceneInfo)"/>
+        /// </summary>
+        /// <param name="targetScenes">
+        /// A reference to all scenes that will be transitioned to.
+        /// </param>
+        /// <param name="setIndexActive">
+        /// Index of the scene in the <paramref name="targetScenes"/> to be set as the active scene.
+        /// </param>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <returns>
+        /// The transition operation.
+        /// </returns>
+        TAsyncSceneArray TransitionToScenesFromAllAsync(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = default);
+
+        /// <summary>
+        /// Async version of the <see cref="ISceneLoader.TransitionToSceneFromAll(ILoadSceneInfo, ILoadSceneInfo)"/>
+        /// </summary>
+        /// <param name="targetSceneReference">
+        /// A reference to the scene that's going to be transitioned to.
+        /// </param>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <returns>
+        /// The transition operation.
+        /// </returns>
+        TAsyncScene TransitionToSceneFromAllAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = default);
+
+        /// <summary>
         /// Async version of the <see cref="ISceneLoader.LoadScenes(ILoadSceneInfo[], int)"/>.
         /// </summary>
         /// <param name="sceneInfos">

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/SceneLoaders/SceneLoaderCoroutine.cs
@@ -33,6 +33,26 @@ namespace MyGameDevTools.SceneLoading
             TransitionToSceneAsync(targetSceneInfo, intermediateSceneInfo);
         }
 
+        public void TransitionToScenesFromScenes(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToScenesFromScenesAsync(targetScenes, fromScenes, setIndexActive, intermediateSceneInfo);
+        }
+
+        public void TransitionToSceneFromScenes(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToSceneFromScenesAsync(targetSceneInfo, fromScenes, intermediateSceneInfo);
+        }
+
+        public void TransitionToScenesFromAll(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToScenesFromAllAsync(targetScenes, setIndexActive, intermediateSceneInfo);
+        }
+
+        public void TransitionToSceneFromAll(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToSceneFromAllAsync(targetSceneInfo, intermediateSceneInfo);
+        }
+
         public void UnloadScenes(ILoadSceneInfo[] sceneInfos)
         {
             UnloadScenesAsync(sceneInfos);
@@ -61,6 +81,26 @@ namespace MyGameDevTools.SceneLoading
         public WaitTask<Scene> TransitionToSceneAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = null)
         {
             return new WaitTask<Scene>(_sceneLoaderAsync.TransitionToSceneAsync(targetSceneReference, intermediateSceneReference).AsTask());
+        }
+
+        public WaitTask<Scene[]> TransitionToScenesFromScenesAsync(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return new WaitTask<Scene[]>(_sceneLoaderAsync.TransitionToScenesFromScenesAsync(targetScenes, fromScenes, setIndexActive, intermediateSceneReference).AsTask());
+        }
+
+        public WaitTask<Scene> TransitionToSceneFromScenesAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return new WaitTask<Scene>(_sceneLoaderAsync.TransitionToSceneFromScenesAsync(targetSceneReference, fromScenes, intermediateSceneReference).AsTask());
+        }
+
+        public WaitTask<Scene[]> TransitionToScenesFromAllAsync(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return new WaitTask<Scene[]>(_sceneLoaderAsync.TransitionToScenesFromAllAsync(targetScenes, setIndexActive, intermediateSceneReference).AsTask());
+        }
+
+        public WaitTask<Scene> TransitionToSceneFromAllAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return new WaitTask<Scene>(_sceneLoaderAsync.TransitionToSceneFromAllAsync(targetSceneReference, intermediateSceneReference).AsTask());
         }
 
         public WaitTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneReferences)

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/SceneLoaders/SceneLoaderUniTask.cs
@@ -35,6 +35,26 @@ namespace MyGameDevTools.SceneLoading
             TransitionToSceneAsync(targetSceneInfo, intermediateSceneInfo);
         }
 
+        public void TransitionToScenesFromScenes(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToScenesFromScenesAsync(targetScenes, fromScenes, setIndexActive, intermediateSceneInfo);
+        }
+
+        public void TransitionToSceneFromScenes(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToSceneFromScenesAsync(targetSceneInfo, fromScenes, intermediateSceneInfo);
+        }
+
+        public void TransitionToScenesFromAll(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToScenesFromAllAsync(targetScenes, setIndexActive, intermediateSceneInfo);
+        }
+
+        public void TransitionToSceneFromAll(ILoadSceneInfo targetSceneInfo, ILoadSceneInfo intermediateSceneInfo = null)
+        {
+            TransitionToSceneFromAllAsync(targetSceneInfo, intermediateSceneInfo);
+        }
+
         public void UnloadScenes(ILoadSceneInfo[] sceneInfos)
         {
             UnloadScenesAsync(sceneInfos);
@@ -63,6 +83,26 @@ namespace MyGameDevTools.SceneLoading
         public UniTask<Scene> TransitionToSceneAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = null)
         {
             return _sceneLoaderAsync.TransitionToSceneAsync(targetSceneReference, intermediateSceneReference).AsTask().AsUniTask();
+        }
+
+        public UniTask<Scene[]> TransitionToScenesFromScenesAsync(ILoadSceneInfo[] targetScenes, ILoadSceneInfo[] fromScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return _sceneLoaderAsync.TransitionToScenesFromScenesAsync(targetScenes, fromScenes, setIndexActive, intermediateSceneReference).AsTask().AsUniTask();
+        }
+
+        public UniTask<Scene> TransitionToSceneFromScenesAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo[] fromScenes, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return _sceneLoaderAsync.TransitionToSceneFromScenesAsync(targetSceneReference, fromScenes, intermediateSceneReference).AsTask().AsUniTask();
+        }
+
+        public UniTask<Scene[]> TransitionToScenesFromAllAsync(ILoadSceneInfo[] targetScenes, int setIndexActive, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return _sceneLoaderAsync.TransitionToScenesFromAllAsync(targetScenes, setIndexActive, intermediateSceneReference).AsTask().AsUniTask();
+        }
+
+        public UniTask<Scene> TransitionToSceneFromAllAsync(ILoadSceneInfo targetSceneReference, ILoadSceneInfo intermediateSceneReference = null)
+        {
+            return _sceneLoaderAsync.TransitionToSceneFromAllAsync(targetSceneReference, intermediateSceneReference).AsTask().AsUniTask();
         }
 
         public UniTask<Scene[]> UnloadScenesAsync(ILoadSceneInfo[] sceneReferences)

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneLoaderTests.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneLoaderTests.cs
@@ -163,6 +163,54 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
+        public IEnumerator TransitionToScenesFromScenes([ValueSource(nameof(_sceneLoaders))] ISceneLoader sceneLoader, [ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.MultipleLoadSceneInfoList))] ILoadSceneInfo[] targetScenes, [ValueSource(nameof(LoadingSceneInfos))] ILoadSceneInfo loadingScene)
+        {
+            int sceneCount = targetScenes.Length;
+
+            var loadedScenes = new List<Scene>(sceneCount);
+
+            sceneLoader.Manager.SceneLoaded += sceneLoaded;
+            sceneLoader.LoadScenes(targetScenes);
+
+            var watch = new Stopwatch();
+            watch.Start();
+            yield return new WaitUntil(() => loadedScenes.Count == sceneCount || watch.ElapsedMilliseconds > SceneTestEnvironment.DefaultTimeout);
+            watch.Stop();
+
+            sceneCount += loadingScene == null ? 0 : 1;
+
+            var unloadedScenes = new List<Scene>(sceneCount);
+            sceneLoader.Manager.SceneUnloaded += sceneUnloaded;
+
+            loadedScenes.Clear();
+            sceneLoader.TransitionToScenesFromScenes(targetScenes, targetScenes, 0, loadingScene);
+
+            watch.Restart();
+            yield return new WaitUntil(() => (loadedScenes.Count == sceneCount && unloadedScenes.Count == sceneCount) || watch.ElapsedMilliseconds > SceneTestEnvironment.DefaultTimeout);
+            watch.Stop();
+
+            sceneLoader.Manager.SceneLoaded -= sceneLoaded;
+            sceneLoader.Manager.SceneUnloaded -= sceneUnloaded;
+
+            yield return new WaitUntil(() => sceneLoader.Manager.TotalSceneCount == targetScenes.Length);
+
+            Assert.AreEqual(sceneCount, loadedScenes.Count);
+            Assert.AreEqual(sceneCount, unloadedScenes.Count);
+
+            void sceneLoaded(Scene scene)
+            {
+                UnityEngine.Debug.Log($"loaded {scene.handle} {scene.name}");
+                loadedScenes.Add(scene);
+            }
+
+            void sceneUnloaded(Scene scene)
+            {
+                UnityEngine.Debug.Log($"unloaded {scene.handle}");
+                unloadedScenes.Add(scene);
+            }
+        }
+
+        [UnityTest]
         public IEnumerator Transition([ValueSource(nameof(_sceneLoaders))] ISceneLoader sceneLoader, [ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SingleLoadSceneInfoList))] ILoadSceneInfo targetScene, [ValueSource(nameof(LoadingSceneInfos))] ILoadSceneInfo loadingScene)
         {
             yield return LoadFirstScene(sceneLoader);

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Refer to the [Migration Guide](https://github.com/mygamedevtools/scene-loader/wi
   * [The Scene Manager](#the-scene-manager)
   * [Load Scene Info](#load-scene-info)
   * [The Scene Loaders](#the-scene-loaders)
+  * [Scene Transitions](#scene-transitions)
   * [Disposable and CancellationTokens](#disposable-and-cancellationtokens)
 * [Practical examples](#practical-examples)
   * [Creating your scene loader](#creating-your-scene-loader)
@@ -357,6 +358,10 @@ Both `LoadSceneAsync` and `UnloadSceneAsync` methods will simply call the `IScen
 It's important to understand that `LoadScene`, `UnloadScene`, and `TransitionToScene` will still invoke asynchronous operations, instead of blocking the execution until they are done.
 You can use the `ISceneManager` events to react to the completion of those methods.
 
+[_[back to top]_](#advanced-scene-manager)
+
+### Scene Transitions
+
 The **Transition** is a combination of load and unload operations to effectively perform scene transitions, with or without an intermediate scene. For example, usually, if you'd want to go from scene A to scene B you would:
 
 1. Load the scene B.
@@ -372,7 +377,14 @@ In this case, you would:
 3. Unload the loading scene.
 
 That's four operations now.
-The `TransitionToScene` and `TransitionToSceneAsync` methods let you only provide where you want to go from the currently active scene and if you want an intermediary scene (loading scene for example).
+The `TransitionToScene` and `TransitionToSceneAsync` methods let you only provide where you want to go from the **current active scene** and if you want an intermediary scene (loading scene for example).
+
+Also, aside from transitioning from the current active scene, you can also use the `TransitionToSceneFromScenes` and `TransitionToSceneFromAll` alternatives:
+
+- `TransitionToSceneFromScenes` - unloads a given group of scenes during transition.
+- `TransitionToSceneFromAll` - unloads all loaded scenes during transition.
+
+Just like the regular `Transition` methods, its variants also have single/multiple scene options as well as async options.
 
 [_[back to top]_](#advanced-scene-manager)
 


### PR DESCRIPTION
Adds new scene transition methods as suggested on #45:

1. `TransitionToScenesFromScenes` - unloads a group of scenes in the transition
2. `TransitionToScenesFromAll` - unloads all loaded scenes in the transition

### Progress

- [x] Feature development
- [x] Tests
- [x] Documentation