### PR TITLE
feat: add reload scene methods and tests

### DIFF
--- a/Packages/com.mygamedevtools.scene-loader/Runtime/CoreSceneManager.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/CoreSceneManager.cs
@@ -147,6 +147,15 @@ namespace MyGameDevTools.SceneLoading
                 : TransitionWithIntermediateAsync(sceneParameters, intermediateSceneReference, linkedSource.Token).RunAndDisposeToken(linkedSource);
         }
 
+        public Task<SceneResult> ReloadActiveSceneAsync(ILoadSceneInfo intermediateSceneReference = null, CancellationToken token = default)
+        {
+            if (_activeScene == null || !_activeScene.SceneReference.IsValid() || !_activeScene.SceneReference.isLoaded)
+                throw new InvalidOperationException($"[{GetType().Name}] Cannot reload the active scene because it is null or not loaded. Make sure to load a scene before trying to reload it.");
+
+            ILoadSceneInfo targetSceneInfo = _activeScene.LoadSceneInfo;
+            return TransitionAsync(new SceneParameters(targetSceneInfo, true), intermediateSceneReference, token);
+        }
+
         public Task<SceneResult> LoadAsync(SceneParameters sceneParameters, IProgress<float> progress = null, CancellationToken token = default)
         {
             CancellationTokenSource linkedSource = CancellationTokenSource.CreateLinkedTokenSource(_lifetimeTokenSource.Token, token);

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneManager.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Interfaces/ISceneManager.cs
@@ -70,6 +70,17 @@ namespace MyGameDevTools.SceneLoading
         Task<SceneResult> TransitionAsync(SceneParameters sceneParameters, ILoadSceneInfo intermediateSceneReference = default, CancellationToken token = default);
 
         /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        Task<SceneResult> ReloadActiveSceneAsync(ILoadSceneInfo intermediateSceneReference = default, CancellationToken token = default);
+
+        /// <summary>
         /// Loads the target scene or group of scenes provided via a <see cref="SceneParameters"/> struct.
         /// You may also provide the desired index to set as the active scene.
         /// Also, you can pass an <see cref="IProgress{T}"/> object to receive the average progress of all loading operations, from 0 to 1.

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/MySceneManager.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/MySceneManager.cs
@@ -101,6 +101,17 @@ namespace MyGameDevTools.SceneLoading
         public static Task<SceneResult> TransitionAsync(SceneParameters sceneParameters, ILoadSceneInfo intermediateSceneReference = default, CancellationToken token = default) => Instance.TransitionAsync(sceneParameters, intermediateSceneReference, token);
 
         /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="intermediateSceneReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAsync(ILoadSceneInfo intermediateSceneReference = null, CancellationToken token = default) => Instance.ReloadActiveSceneAsync(intermediateSceneReference, token);
+
+        /// <summary>
         /// Loads the target scene or group of scenes provided via a <see cref="SceneParameters"/> struct.
         /// You may also provide the desired index to set as the active scene.
         /// Also, you can pass an <see cref="IProgress{T}"/> object to receive the average progress of all loading operations, from 0 to 1.
@@ -518,6 +529,52 @@ namespace MyGameDevTools.SceneLoading
         /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
         /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes loaded.</returns>
         public static Task<SceneResult> TransitionAddressableAsync(string targetAddress, string loadingAddress = null, CancellationToken token = default) => Instance.TransitionAddressableAsync(targetAddress, loadingAddress, token);
+#endif
+
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingSceneName">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAsync(string loadingSceneName = null, CancellationToken token = default) => Instance.ReloadActiveSceneAsync(loadingSceneName, token);
+
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingBuildIndex">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAsync(int loadingBuildIndex = -1, CancellationToken token = default) => Instance.ReloadActiveSceneAsync(loadingBuildIndex, token);
+
+#if ENABLE_ADDRESSABLES
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingAssetReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAddressableAsync(AssetReference loadingAssetReference = null, CancellationToken token = default) => Instance.ReloadActiveSceneAddressableAsync(loadingAssetReference, token);
+
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingAddress">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAddressableAsync(string loadingAddress = null, CancellationToken token = default) => Instance.ReloadActiveSceneAddressableAsync(loadingAddress, token);
 #endif
 
         /// <summary>

--- a/Packages/com.mygamedevtools.scene-loader/Runtime/Utilities/SceneManagerExtensions.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Runtime/Utilities/SceneManagerExtensions.cs
@@ -448,6 +448,68 @@ namespace MyGameDevTools.SceneLoading
 #endif
 
         /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingSceneName">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAsync(this ISceneManager sceneManager, string loadingSceneName = null, CancellationToken token = default)
+        {
+            ILoadSceneInfo loadingSceneInfo = string.IsNullOrWhiteSpace(loadingSceneName) ? null : new LoadSceneInfoName(loadingSceneName);
+            return sceneManager.ReloadActiveSceneAsync(loadingSceneInfo, token);
+        }
+
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingBuildIndex">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAsync(this ISceneManager sceneManager, int loadingBuildIndex = -1, CancellationToken token = default)
+        {
+            ILoadSceneInfo loadingSceneInfo = loadingBuildIndex >= 0 ? new LoadSceneInfoIndex(loadingBuildIndex) : null;
+            return sceneManager.ReloadActiveSceneAsync(loadingSceneInfo, token);
+        }
+
+#if ENABLE_ADDRESSABLES
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingAssetReference">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAddressableAsync(this ISceneManager sceneManager, AssetReference loadingAssetReference = null, CancellationToken token = default)
+        {
+            ILoadSceneInfo loadingSceneInfo = loadingAssetReference != null ? new LoadSceneInfoAssetReference(loadingAssetReference) : null;
+            return sceneManager.ReloadActiveSceneAsync(loadingSceneInfo, token);
+        }
+
+        /// <summary>
+        /// Reloads the active scene with an optional intermediate loading scene.
+        /// </summary>
+        /// <param name="loadingAddress">
+        /// A reference to the scene that's going to be loaded as the transition intermediate (as a loading scene).
+        /// If null, the transition will not have an intermediate loading scene.
+        /// </param>
+        /// <param name="token">Optional token to manually cancel the operation. Note that Unity Scene Manager operations cannot be manually canceled and will continue to run.</param>
+        /// <returns>A <see cref="System.Threading.Tasks.Task{TResult}"/> with all scenes reloaded.</returns>
+        public static Task<SceneResult> ReloadActiveSceneAddressableAsync(this ISceneManager sceneManager, string loadingAddress = null, CancellationToken token = default)
+        {
+            ILoadSceneInfo loadingSceneInfo = string.IsNullOrWhiteSpace(loadingAddress) ? null : new LoadSceneInfoAddress(loadingAddress);
+            return sceneManager.ReloadActiveSceneAsync(loadingSceneInfo, token);
+        }
+#endif
+
+        /// <summary>
         /// Unloads the target scene or group of scenes.
         /// </summary>
         /// <param name="sceneNames">

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneManager_AssetReferenceTests.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneManager_AssetReferenceTests.cs
@@ -42,6 +42,12 @@ namespace MyGameDevTools.SceneLoading.Tests
         }
 
         [UnityTest]
+        public IEnumerator Reload_AssetReference([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager, [ValueSource(nameof(LoadingSceneInfos))] ILoadSceneInfo loadingScene)
+        {
+            yield return Reload(manager, _assetReferenceLoadSceneInfos[0], loadingScene);
+        }
+
+        [UnityTest]
         public IEnumerator Unload_AssetReference([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
         {
             yield return Unload(manager, new SceneParameters(_assetReferenceLoadSceneInfos));

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneManager_ExtensionTests.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/SceneManager_ExtensionTests.cs
@@ -118,6 +118,32 @@ namespace MyGameDevTools.SceneLoading.Tests
 #endif
 
         [UnityTest]
+        public IEnumerator Reload_Extension_ByName([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
+        {
+            yield return Reload_Template(manager, new LoadSceneInfoName(SceneBuilder.SceneNames[1]), () => manager.ReloadActiveSceneAsync(SceneBuilder.SceneNames[1]));
+        }
+
+        [UnityTest]
+        public IEnumerator Reload_Extension_ByIndex([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
+        {
+            yield return Reload_Template(manager, new LoadSceneInfoIndex(1), () => manager.ReloadActiveSceneAsync(1));
+        }
+
+#if ENABLE_ADDRESSABLES
+        [UnityTest]
+        public IEnumerator Reload_Extension_Addressable_ByAddress([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
+        {
+            yield return Reload_Template(manager, new LoadSceneInfoAddress(SceneBuilder.SceneNames[1]), () => manager.ReloadActiveSceneAddressableAsync(SceneBuilder.SceneNames[1]));
+        }
+
+        [UnityTest]
+        public IEnumerator Reload_Extension_Addressable_ByAssetReference([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
+        {
+            yield return Reload_Template(manager, new LoadSceneInfoAssetReference(_assetReferences[1]), () => manager.ReloadActiveSceneAddressableAsync(_assetReferences[1]));
+        }
+#endif
+
+        [UnityTest]
         public IEnumerator Unload_Extension_ByIndex([ValueSource(typeof(SceneTestEnvironment), nameof(SceneTestEnvironment.SceneManagers))] ISceneManager manager)
         {
             yield return Unload_Template(manager, () => manager.LoadAsync(1, true), () => manager.UnloadAsync(1), 1);

--- a/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/StaticSceneManager_ExtensionTests.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Tests/Runtime/StaticSceneManager_ExtensionTests.cs
@@ -138,6 +138,32 @@ namespace MyGameDevTools.SceneLoading.Tests
 #endif
 
         [UnityTest]
+        public IEnumerator Reload_Extension_ByName()
+        {
+            yield return Reload_Template(new LoadSceneInfoName(SceneBuilder.SceneNames[1]), () => MySceneManager.ReloadActiveSceneAsync(SceneBuilder.SceneNames[1]));
+        }
+
+        [UnityTest]
+        public IEnumerator Reload_Extension_ByIndex()
+        {
+            yield return Reload_Template(new LoadSceneInfoIndex(1), () => MySceneManager.ReloadActiveSceneAsync(1));
+        }
+
+#if ENABLE_ADDRESSABLES
+        [UnityTest]
+        public IEnumerator Reload_Extension_Addressable_ByAddress()
+        {
+            yield return Reload_Template(new LoadSceneInfoAddress(SceneBuilder.SceneNames[1]), () => MySceneManager.ReloadActiveSceneAddressableAsync(SceneBuilder.SceneNames[1]));
+        }
+
+        [UnityTest]
+        public IEnumerator Reload_Extension_Addressable_ByAssetReference()
+        {
+            yield return Reload_Template(new LoadSceneInfoAssetReference(_assetReferences[1]), () => MySceneManager.ReloadActiveSceneAddressableAsync(_assetReferences[1]));
+        }
+#endif
+
+        [UnityTest]
         public IEnumerator Unload_Extension_ByIndex()
         {
             yield return Unload_Template(() => MySceneManager.LoadAsync(1, true), () => MySceneManager.UnloadAsync(1), 1);


### PR DESCRIPTION
This feature adds the ability to reload the active scene, as requested by @miltoncandelero in #51.

You can optionally pass an intermediate loading scene for the reload operation. Internally, it relays the call to a `Transition` method.

Closes #51 