### PR TITLE
fix: reorder #if statements to fix compilation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user

--- a/Packages/com.mygamedevtools.scene-loader/Samples/LoadingSceneExamples/Scripts/Editor/MaterialPipelineConverter.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Samples/LoadingSceneExamples/Scripts/Editor/MaterialPipelineConverter.cs
@@ -27,11 +27,11 @@ public static class MaterialPipelineConverter
 
     public static void ConvertMaterials()
     {
+#if CONVERT_MATERIALS
         RenderPipelineAsset renderPipeline = GraphicsSettings.currentRenderPipeline;
         if (!renderPipeline)
             return;
 
-#if CONVERT_MATERIALS
         string[] materialPaths = AssetDatabase.FindAssets("t:Material")
             .Select(AssetDatabase.GUIDToAssetPath)
             .Where(path => path.Contains(_partialPath))

--- a/Packages/com.mygamedevtools.scene-loader/Samples/LoadingSceneExamples/Scripts/Editor/MaterialPipelineConverter.cs
+++ b/Packages/com.mygamedevtools.scene-loader/Samples/LoadingSceneExamples/Scripts/Editor/MaterialPipelineConverter.cs
@@ -77,6 +77,7 @@ public static class MaterialPipelineConverter
 #endif
 }
 
+#if CONVERT_MATERIALS
 #if CONVERT_HDRP
 // Modified original from `Packages/com.unity.render-pipelines.high-definition/Editor/Material/Lit/StandardsToHDLitMaterialUpgrader.cs`
 internal class StandardsToHDLitMaterialUpgrader : MaterialUpgrader
@@ -127,4 +128,5 @@ internal class StandardsToHDLitMaterialUpgrader : MaterialUpgrader
         HDShaderUtils.ResetMaterialKeywords(dstMaterial);
     }
 }
+#endif
 #endif


### PR DESCRIPTION
Fixed compilation errors with the `MaterialPipelineConverter`, that didn't have the correct placement of `#if` statements.

This error slipped through because we don't hide the Samples folder in the hierarchy when editing the package. One of the sample's `.asmdef` defines `CONVERT_MATERIALS`, so we never got to see what it would be like to not have it defined. Turns out it was breaking for everyone who didn't have samples installed.

Closes #54 