### PR TITLE
fix: Add Unity 6.3 Package Signing

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -151,6 +151,10 @@ jobs:
           -cloudOrganization "${{ secrets.UNITY_ORG_ID }}" \
           -logFile -
 
+    - name: 📥 Install GitHub CLI
+      run: |
+        apt-get update && apt-get install -y gh
+
     - name: 📎 Attach Signed UPM Package to Release
       run: |
         gh release upload ${{ env.releaseVersion }} ./*.tgz --clobber

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -13,6 +13,8 @@ on:
         required: true
       UNITY_PASSWORD:
         required: true
+      UNITY_ORG_ID:
+        required: true
 
 jobs:
   package-upm:
@@ -107,5 +109,48 @@ jobs:
     - name: 📎 Attach Unity Package to Release
       run: |
         gh release upload ${{ env.releaseVersion }} ./*.unitypackage --clobber
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  detect-unity-version:
+    name: Detect Unity Version
+    uses: ./.github/workflows/detect-unity-versions.yml
+    with:
+      version-streams: "6.3"
+
+  export-signed-upm:
+    name: Export Signed UPM Package
+    needs: detect-unity-version
+    runs-on: ubuntu-latest
+    container:
+      image: unityci/editor:ubuntu-${{ fromJSON(needs.detect-unity-version.outputs.versions)[0] }}-base-3
+    permissions:
+      contents: write
+    env:
+      releaseVersion: ${{ inputs.version }}
+    steps:
+    - name: 📂 Checkout
+      uses: actions/checkout@v5
+
+    - name: 📦 Prepare Package
+      uses: ./.github/actions/prepare-package
+      with:
+        version: ${{ env.releaseVersion }}
+
+    - name: 🔐 Activate Unity License
+      run: |
+        echo "${{ secrets.UNITY_LICENSE }}" | base64 -d > /unity.ulf
+        unity-editor -batchmode -manualLicenseFile /unity.ulf -logFile - || true
+
+    - name: 📦 Export Signed UPM Package
+      run: |
+        unity-editor -batchmode -quit \
+          -upmPack "$PACKAGE_PATH" "./com.mygamedevtools.scene-loader-${{ env.releaseVersion }}.tgz" \
+          -cloudOrganization "${{ secrets.UNITY_ORG_ID }}" \
+          -logFile -
+
+    - name: 📎 Attach Signed UPM Package to Release
+      run: |
+        gh release upload ${{ env.releaseVersion }} ./*.tgz --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,6 +15,10 @@ on:
         required: true
       UNITY_ORG_ID:
         required: true
+      UPM_SERVICE_ACCOUNT_KEY_ID:
+        required: true
+      UPM_SERVICE_ACCOUNT_KEY_SECRET:
+        required: true
 
 jobs:
   package-upm:
@@ -112,22 +116,17 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  detect-unity-version:
-    name: Detect Unity Version
-    uses: ./.github/workflows/detect-unity-versions.yml
-    with:
-      version-streams: "6.3"
-
   export-signed-upm:
     name: Export Signed UPM Package
-    needs: detect-unity-version
     runs-on: ubuntu-latest
-    container:
-      image: unityci/editor:ubuntu-${{ fromJSON(needs.detect-unity-version.outputs.versions)[0] }}-base-3
     permissions:
       contents: write
     env:
       releaseVersion: ${{ inputs.version }}
+      # Read by the `upm` CLI when it signs the tarball
+      UPM_SERVICE_ACCOUNT_KEY_ID: ${{ secrets.UPM_SERVICE_ACCOUNT_KEY_ID }}
+      UPM_SERVICE_ACCOUNT_KEY_SECRET: ${{ secrets.UPM_SERVICE_ACCOUNT_KEY_SECRET }}
+      DIST_DIR: ${{ github.workspace }}/upm-dist
     steps:
     - name: 📂 Checkout
       uses: actions/checkout@v5
@@ -137,26 +136,64 @@ jobs:
       with:
         version: ${{ env.releaseVersion }}
 
-    - name: 🔐 Activate Unity License
+    - name: 🔄 Rename Samples Folder
       run: |
-        echo "${{ secrets.UNITY_LICENSE }}" > /unity.ulf
-        unity-editor -batchmode -manualLicenseFile /unity.ulf -logFile - || true
+        if [[ -d "$PACKAGE_PATH/Samples" ]]; then
+          mv "$PACKAGE_PATH/Samples" "$PACKAGE_PATH/Samples~"
+          rm -f "$PACKAGE_PATH/Samples.meta"
+        fi
 
-    - name: 📦 Export Signed UPM Package
+    - name: 🛠️ Install Unity Package Manager CLI
       run: |
-        unity-editor -batchmode -quit \
-          -username "${{ secrets.UNITY_EMAIL }}" \
-          -password "${{ secrets.UNITY_PASSWORD }}" \
-          -upmPack "$PACKAGE_PATH" "./com.mygamedevtools.scene-loader-${{ env.releaseVersion }}.tgz" \
-          -cloudOrganization "${{ secrets.UNITY_ORG_ID }}" \
-          -logFile -
+        curl -fsSL https://cdn.packages.unity.com/upm-cli/install.sh -o "$RUNNER_TEMP/install-upm.sh"
+        bash "$RUNNER_TEMP/install-upm.sh"
+        echo "$HOME/.upm/bin" >> "$GITHUB_PATH"
 
-    - name: 📥 Install GitHub CLI
+    - name: 🔏 Pack & Sign UPM Package
       run: |
-        apt-get update && apt-get install -y gh
+        mkdir -p "$DIST_DIR"
+        upm --version
+        upm pack "$PACKAGE_PATH" \
+          --organization-id "${{ secrets.UNITY_ORG_ID }}" \
+          --destination "$DIST_DIR"
+
+    - name: ✅ Verify Signed Package
+      run: |
+        shopt -s nullglob
+        archives=("$DIST_DIR"/*.tgz "$DIST_DIR"/*.tar.gz)
+        if [[ ${#archives[@]} -ne 1 ]]; then
+          echo "::error::Expected exactly one signed archive in $DIST_DIR, found ${#archives[@]}"
+          exit 1
+        fi
+        archive="${archives[0]}"
+
+        tar -tzf "$archive" | grep -qx 'package/package.json' \
+          || { echo "::error::Tarball is missing package/package.json"; exit 1; }
+        tar -tzf "$archive" | grep -qx 'package/.attestation.p7m' \
+          || { echo "::error::Tarball is unsigned - missing package/.attestation.p7m"; exit 1; }
+
+        packedName=$(tar -xOzf "$archive" package/package.json | jq -r '.name')
+        packedVersion=$(tar -xOzf "$archive" package/package.json | jq -r '.version')
+        if [[ "$packedVersion" != "$releaseVersion" ]]; then
+          echo "::error::Packed version $packedVersion does not match release $releaseVersion"
+          exit 1
+        fi
+
+        # OpenUPM resolves the release asset by the "<package-name>-" prefix, so pin the filename
+        expected="$DIST_DIR/$packedName-$packedVersion.tgz"
+        [[ "$archive" == "$expected" ]] || mv "$archive" "$expected"
+
+        echo "PACKAGE_ARCHIVE=$expected" >> "$GITHUB_ENV"
+        echo "✅ Signed \`$packedName@$packedVersion\`" | tee -a $GITHUB_STEP_SUMMARY
+
+    - name: 🗂️ Upload Signed UPM Package Artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: com.mygamedevtools.scene-loader-${{ env.releaseVersion }}-signed
+        path: ${{ env.PACKAGE_ARCHIVE }}
 
     - name: 📎 Attach Signed UPM Package to Release
       run: |
-        gh release upload ${{ env.releaseVersion }} ./*.tgz --clobber
+        gh release upload "$releaseVersion" "$PACKAGE_ARCHIVE" --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: 🔐 Activate Unity License
       run: |
-        echo "${{ secrets.UNITY_LICENSE }}" | base64 -d > /unity.ulf
+        echo "${{ secrets.UNITY_LICENSE }}" > /unity.ulf
         unity-editor -batchmode -manualLicenseFile /unity.ulf -logFile - || true
 
     - name: 📦 Export Signed UPM Package

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -145,6 +145,8 @@ jobs:
     - name: 📦 Export Signed UPM Package
       run: |
         unity-editor -batchmode -quit \
+          -username "${{ secrets.UNITY_EMAIL }}" \
+          -password "${{ secrets.UNITY_PASSWORD }}" \
           -upmPack "$PACKAGE_PATH" "./com.mygamedevtools.scene-loader-${{ env.releaseVersion }}.tgz" \
           -cloudOrganization "${{ secrets.UNITY_ORG_ID }}" \
           -logFile -

--- a/.github/workflows/versioning-manual.yml
+++ b/.github/workflows/versioning-manual.yml
@@ -18,6 +18,12 @@ on:
         required: true
       UNITY_PASSWORD:
         required: true
+      UNITY_ORG_ID:
+        required: true
+      UPM_SERVICE_ACCOUNT_KEY_ID:
+        required: true
+      UPM_SERVICE_ACCOUNT_KEY_SECRET:
+        required: true
 
 jobs:
   calculate-version:

--- a/.github/workflows/versioning-semver.yml
+++ b/.github/workflows/versioning-semver.yml
@@ -19,6 +19,8 @@ on:
         required: true
       UNITY_PASSWORD:
         required: true
+      UNITY_ORG_ID:
+        required: true
 
 jobs:
   semantic-release:

--- a/.github/workflows/versioning-semver.yml
+++ b/.github/workflows/versioning-semver.yml
@@ -21,6 +21,10 @@ on:
         required: true
       UNITY_ORG_ID:
         required: true
+      UPM_SERVICE_ACCOUNT_KEY_ID:
+        required: true
+      UPM_SERVICE_ACCOUNT_KEY_SECRET:
+        required: true
 
 jobs:
   semantic-release:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -29,8 +29,7 @@
       "@semantic-release/npm",
       {
         "npmPublish": false,
-        "pkgRoot": "Packages/com.mygamedevtools.scene-loader",
-        "tarballDir": "dist"
+        "pkgRoot": "Packages/com.mygamedevtools.scene-loader"
       }
     ],
     [
@@ -43,11 +42,6 @@
         "message": "ci(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": "dist/*.tgz"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/Packages/com.mygamedevtools.scene-loader/package.json
+++ b/Packages/com.mygamedevtools.scene-loader/package.json
@@ -3,11 +3,11 @@
   "version": "4.1.1",
   "displayName": "My Scene Manager",
   "description": "This package simplifies scene operations: load, unload and transition.\nFor example, this is how you perform a scene transition:\n\n┃MySceneManager.TransitionAsync(\"my-target-scene\", \"my-loading-scene\");\n\nInstead of:\n\n┃ yield return SceneManager.LoadSceneAsync(\"my-loading-scene\",\n┃        LoadSceneMode.Additive);\n┃ yield return SceneManager.LoadSceneAsync(\"my-target-scene\",\n┃        LoadSceneMode.Additive);\n┃\n┃ SceneManager.SetActiveScene(\n┃        SceneManager.GetSceneByName(\"my-target-scene\"));\n┃\n┃ SceneManager.UnloadSceneAsync(\"my-loading-scene\");\n┃ SceneManager.UnloadSceneAsync(\"my-previous-scene\");\n\nYou can also take advantage of these features:\n\n▪ Unified API for addressable and non-addressable scenes.\n▪ Awaitable scene operations.\n▪ Modular implementation with interfaces.\n▪ Load, unload or transition to multiple scenes.",
-  "unity": "2021.3",
+  "unity": "6000.0",
   "keywords": [],
   "author": {
     "name": "My GameDev Tools",
-    "email": "joao.borks@gmail.com.br",
+    "email": "support@mygamedevtools.com",
     "url": "https://github.com/mygamedevtools"
   },
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -45,10 +45,30 @@ SceneManager.UnloadSceneAsync("my-previous-scene");
 
 ## 📦 Installation
 
-You can install the package via **[OpenUPM](https://openupm.com/packages/com.mygamedevtools.scene-loader)**, **Git**, **Tarball** and the **[Unity Asset Store](https://assetstore.unity.com/packages/slug/313159)**.
+You can install the package via the **[Unity Asset Store](https://assetstore.unity.com/packages/slug/313159)**, **Tarball**, **[OpenUPM](https://openupm.com/packages/com.mygamedevtools.scene-loader)** and **Git**.
 Check the full installation guide in the [documentation](https://scene-loader.mygamedevtools.com/docs/next/getting-started/installation).
 
-#### OpenUPM
+#### Unity Asset Store
+
+1. Obtain the package for free at the [Asset Store Page](https://assetstore.unity.com/packages/slug/313159).
+2. With your Unity project open, click `Open in Unity`.
+3. The `Package Manager` will open with the package selected.
+4. Click `Download` or `Update`, depending on the local cache.
+5. Click `Import`.
+6. Make sure everything is selected and click `Import` again.
+
+> [!NOTE]
+> When updating from the Asset Store, make sure to remove the previous version completely before adding the updated version.
+
+#### Tarball (UPM Signed)
+
+1. Choose the [release](https://github.com/mygamedevtools/scene-loader/releases) you want to install and download the `com.mygamedevtools.scene-loader-<release>.tgz` asset.
+2. Open `Window/Package Manager`.
+3. Click <kbd>+</kbd>.
+4. Select `Install package from tarball...`.
+5. Select the `com.mygamedevtools.scene-loader-<release>.tgz` file you downloaded.
+
+#### OpenUPM (UPM Unsigned)
 
 * Open `Edit/Project Settings/Package Manager`.
 * Add a new **Scoped Registry** (or edit the existing _OpenUPM_ entry):
@@ -63,33 +83,13 @@ Check the full installation guide in the [documentation](https://scene-loader.my
 * Select `Advanced Scene Manager` under `My GameDev Tools`.
 * Click `Install`.
 
-#### Git
+#### Git (UPM Unsigned)
 
 1. Open `Window/Package Manager`.
 2. Click <kbd>+</kbd>.
 3. Select `Install package from git URL...`.
 4. Paste `https://github.com/mygamedevtools/scene-loader.git#upm` into url.
 5. Click `Add`.
-
-#### Tarball
-
-1. Choose the [release](https://github.com/mygamedevtools/scene-loader/releases) you want to install and download the `com.mygamedevtools.scene-loader-<release>.tgz` asset.
-2. Open `Window/Package Manager`.
-3. Click <kbd>+</kbd>.
-4. Select `Install package from tarball...`.
-5. Select the `com.mygamedevtools.scene-loader-<release>.tgz` file you downloaded.
-
-#### Unity Asset Store
-
-1. Obtain the package at the [Asset Store Page](https://assetstore.unity.com/packages/slug/313159).
-2. With your Unity project open, click `Open in Unity`.
-3. The `Package Manager` will open with the package selected.
-4. Click `Download` or `Update`, depending on the local cache.
-5. Click `Import`.
-6. Make sure everything is selected and click `Import` again.
-
-> [!NOTE]
-> When updating from the Asset Store, make sure to remove the previous version completely before adding the updated version.
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ Check the full installation guide in the [documentation](https://scene-loader.my
 4. Select `Install package from tarball...`.
 5. Select the `com.mygamedevtools.scene-loader-<release>.tgz` file you downloaded.
 
-#### OpenUPM (UPM Unsigned)
+#### OpenUPM (UPM Signed)
+
+> [!NOTE]
+> OpenUPM republishes the signed tarball from each GitHub release unchanged. Versions published before signing was introduced remain unsigned.
 
 * Open `Edit/Project Settings/Package Manager`.
 * Add a new **Scoped Registry** (or edit the existing _OpenUPM_ entry):


### PR DESCRIPTION
Implements [package signing](https://docs.unity3d.com/6000.3/Documentation/Manual/upm-signature.html) from Unity 6.3+. It signs the tarball exported to the GitHub Release, which also updates the OpenUPM package.

<img width="404" height="94" alt="image" src="https://github.com/user-attachments/assets/ebf49591-539d-4dd6-b5db-b56c99b02799" />