### PR TITLE
fix(ci): restore PAT for the semantic-release commit

### DIFF
--- a/.github/workflows/versioning-semver.yml
+++ b/.github/workflows/versioning-semver.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
     secrets:
+      # PAT: the release commit targets a protected branch, which the default
+      # GITHUB_TOKEN (github-actions[bot]) is not allowed to push to
+      GH_TOKEN:
+        required: true
       UNITY_LICENSE:
         required: true
       UNITY_EMAIL:
@@ -57,7 +61,7 @@ jobs:
         dry_run: ${{ inputs.dryRun }}
         ci: ${{ inputs.blockPullRequestRelease }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     - name: 📄 Summary
       run: |


### PR DESCRIPTION
## Problem

The post-merge Release run for #58 failed before creating anything:

```
GH006: Protected branch update failed for refs/heads/main.
- Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

`@semantic-release/git` pushes the `ci(release): x.y.z` commit (bumped `package.json` + `CHANGELOG.md`) straight to `main`. `main` requires changes to go through a PR, and the default `GITHUB_TOKEN` runs as `github-actions[bot]` — not an admin, and not in any bypass allowance — so the push is rejected.

## Cause

Pre-existing regression from #57, unrelated to package signing. The `release-template.yml` that #57 replaced used a PAT for exactly this:

```yaml
- name: 🚀 Semantic Release
  uses: cycjimmy/semantic-release-action@v4
  env:
    GH_TOKEN: ${{ secrets.GH_TOKEN }}
```

The rewrite dropped both the `GH_TOKEN` secret declaration and its use, substituting `GITHUB_TOKEN`. Branch protection has `enforce_admins: false`, which is why an admin's PAT could push and the bot cannot.

It stayed hidden for six months because every commit landing on `main` since #57 was `ci:` or `chore:` — neither triggers a release under the angular preset, so semantic-release never reached the push in its `prepare` step. #58's `fix:` was the first releasable commit since.

## Fix

Restores the `GH_TOKEN` declaration and uses it for the semantic-release step. semantic-release resolves git auth as `GH_TOKEN || GITHUB_TOKEN`, so setting `GH_TOKEN` alone is sufficient.

## State

The failure happened in `prepare`, before `publish` — so there is **no 4.1.2 tag and no 4.1.2 release**. Nothing partial to clean up. The `fix:` commit from #58 remains unreleased and will be picked up on the next successful run.

Merging this triggers Release again (the workflow change isn't covered by `paths-ignore: '**.md'`), which should cut 4.1.2 and attach the signed tarball. Signing itself is already verified — `4.1.2-pre.5` carries a valid attestation from Unity's DigiCert chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
