### PR TITLE
docs: fix package display name in OpenUPM install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Check the full installation guide in the [documentation](https://scene-loader.my
 * Click `Apply`.
 * Open `Window/Package Manager`.
 * In the left column, select `Open UPM` inside `My Registries`.
-* Select `Advanced Scene Manager` under `My GameDev Tools`.
+* Select `My Scene Manager` under `My GameDev Tools`.
 * Click `Install`.
 
 #### Git (UPM Unsigned)


### PR DESCRIPTION
The OpenUPM installation steps told users to select `Advanced Scene Manager` in the Package Manager, but the package is listed as `My Scene Manager` — matching the `displayName` in `Packages/com.mygamedevtools.scene-loader/package.json`.

Spotted while updating the [documentation site](https://github.com/mygamedevtools/scene-loader-docs) to reflect #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)