### PR TITLE
ci: detect Unity versions instead of hardcoding streams

### DIFF
--- a/.github/workflows/detect-unity-versions.yml
+++ b/.github/workflows/detect-unity-versions.yml
@@ -3,8 +3,9 @@ on:
   workflow_call:
     inputs:
       version-streams:
-        description: 'Comma-separated Unity version streams to detect (e.g., "6.0,6.3")'
-        required: true
+        description: 'Optional override, comma-separated (e.g. "6000.0,6000.3"). Empty = auto-detect every active LTS stream.'
+        required: false
+        default: ''
         type: string
     outputs:
       versions:
@@ -18,36 +19,54 @@ jobs:
     outputs:
       versions: ${{ steps.detect.outputs.versions }}
     steps:
-      - name: Query Docker Hub for latest Unity versions
+      - name: Resolve Unity LTS versions
         id: detect
         run: |
-          # Query Docker Hub API for unityci/editor tags
-          TAGS=$(curl -s "https://registry.hub.docker.com/v2/repositories/unityci/editor/tags?page_size=100")
+          set -o pipefail
 
-          # Parse input version streams (e.g., "6.0,6.3,6.4")
-          IFS=',' read -ra STREAMS <<< "${{ inputs.version-streams }}"
+          STREAMS_INPUT="${{ inputs.version-streams }}"
 
-          # Build JSON array of detected versions
+          if [ -n "$STREAMS_INPUT" ]; then
+            MODE="pinned"
+            STREAM_LIST=$(echo "$STREAMS_INPUT" | tr ',' '\n' | xargs -n1 | sed -E 's/^6\./6000./' | sort -Vu | tr '\n' ' ')
+          else
+            MODE="auto"
+            # Unity's release API is the only source that labels a stream LTS.
+            # limit caps at 25; that window spans several months, so every
+            # actively-released LTS stream appears in it.
+            LTS=$(curl -sf "https://services.api.unity.com/unity/editor/release/v1/releases?stream=LTS&limit=25&order=RELEASE_DATE_DESC") || {
+              echo "::error::Unity release API query failed"
+              exit 1
+            }
+            STREAM_LIST=$(echo "$LTS" | jq -r '.results[].version | split(".")[0:2] | join(".")' | sort -Vu | tr '\n' ' ')
+          fi
+
+          read -ra STREAMS <<< "$STREAM_LIST"
+          if [ ${#STREAMS[@]} -eq 0 ]; then
+            echo "::error::No Unity LTS streams found ($MODE mode)"
+            exit 1
+          fi
+          echo "LTS streams ($MODE): ${STREAMS[*]}"
+
           VERSIONS="["
           FIRST=true
+          MISSING=""
 
           for STREAM in "${STREAMS[@]}"; do
-            # Trim whitespace
-            STREAM=$(echo "$STREAM" | xargs)
+            ESCAPED=${STREAM//./\\.}
 
-            # Convert stream format (6.0 -> 6000.0, 6.3 -> 6000.3)
-            MINOR=$(echo "$STREAM" | cut -d. -f2)
-            SEARCH_PATTERN="6000\.${MINOR}\.[0-9]+f[0-9]"
+            # Query per stream: tags are paginated by last_updated, so an unfiltered
+            # page only covers recently pushed streams. `name` keeps this stream on page 1.
+            TAGS=$(curl -sf "https://registry.hub.docker.com/v2/repositories/unityci/editor/tags?page_size=100&name=${STREAM}") || TAGS=""
 
-            # Find latest version for this stream
-            # Extract version number from tag formats like:
-            # - ubuntu-6000.0.66f1-android-3.2.1
-            # - windows-6000.3.5f1-base-3
-            # - 6000.0.66f1-android-3
-            VERSION=$(echo "$TAGS" | jq -r '.results[].name' | \
-              grep -E "$SEARCH_PATTERN" | \
-              sed -E 's/.*(6000\.[0-9]+\.[0-9]+f[0-9]+).*/\1/' | \
-              sort -V | uniq | tail -1)
+            # Tags look like ubuntu-6000.0.66f1-android-3.2.1 or 6000.3.5f1-base-3
+            VERSION=""
+            if [ -n "$TAGS" ]; then
+              VERSION=$(echo "$TAGS" | jq -r '.results[]? | .name' | \
+                grep -E "${ESCAPED}\.[0-9]+f[0-9]" | \
+                sed -E "s/.*(${ESCAPED}\.[0-9]+f[0-9]+).*/\1/" | \
+                sort -V | uniq | tail -1) || VERSION=""
+            fi
 
             if [ -n "$VERSION" ]; then
               if [ "$FIRST" = true ]; then
@@ -58,10 +77,27 @@ jobs:
               VERSIONS+="\"$VERSION\""
               echo "Detected Unity $STREAM LTS: $VERSION"
             else
-              echo "Warning: No version found for Unity $STREAM"
+              MISSING+=" $STREAM"
             fi
           done
 
           VERSIONS+="]"
+
+          if [ -n "$MISSING" ]; then
+            if [ "$MODE" = "pinned" ]; then
+              # An explicitly requested stream must exist; a miss is a config error.
+              echo "::error::No unityci/editor image for pinned stream(s):$MISSING"
+              exit 1
+            fi
+            # In auto mode a new LTS stream routinely lands before game-ci builds its
+            # image. Warn instead of failing, but never let the matrix go empty.
+            echo "::warning::No unityci/editor image yet for LTS stream(s):$MISSING"
+          fi
+
+          if [ "$FIRST" = true ]; then
+            echo "::error::No Unity versions resolved for any LTS stream"
+            exit 1
+          fi
+
           echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
           echo "Output matrix: $VERSIONS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,31 @@
 name: 🧪 Tests
 on:
+  # Keep these two lists in sync. GitHub Actions does not support YAML anchors.
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
+    paths:
+      # The Unity project: the package under test, the manifests that resolve its
+      # dependencies, the vendored packages it compiles alongside, the Addressables
+      # setup the tests run against, and the editor version the project opens with.
+      - 'Assets/**'
+      - 'Packages/**'
+      - 'ProjectSettings/**'
+      # The workflows that decide what gets tested and how.
+      - '.github/workflows/test.yml'
+      - '.github/workflows/detect-unity-versions.yml'
+      # Docs never change behaviour, including docs shipped inside a package.
+      - '!**.md'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
+    paths:
+      - 'Assets/**'
+      - 'Packages/**'
+      - 'ProjectSettings/**'
+      - '.github/workflows/test.yml'
+      - '.github/workflows/detect-unity-versions.yml'
+      - '!**.md'
   schedule:
     # Run on the 1st of every month at 2 AM UTC
     - cron: '0 2 1 * *'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
   detect-versions:
     name: Detect Unity Versions
     uses: ./.github/workflows/detect-unity-versions.yml
-    with:
-      version-streams: "6.0,6.3"
 
   test:
     name: Unity ${{ matrix.unityVersion }} - playmode


### PR DESCRIPTION
## The problem

The test matrix had silently collapsed to a **single** editor version. The most recent run of the test workflow on `main`:

```
Detect Unity Versions / Detect Latest Unity LTS Versions   success
Unity 6000.0.80f1 - playmode                               success
```

One playmode job, not two — and the workflow was green, so nothing surfaced it.

`detect-unity-versions.yml` fetched a single unfiltered page of `unityci/editor` tags:

```
tags?page_size=100
```

That endpoint is paginated and ordered by `last_updated`, and the repo carries thousands of tags. Page 1 currently holds only two Unity versions:

```
43 x 6000.0.80f1
57 x 6000.5.5f1
```

No `6000.3.*` at all. Those tags exist — 1482 of them, newest `6000.3.20f1` — but sit on pages 2, 4 and 5. So the 6.3 grep matched nothing, the script printed `Warning: No version found for Unity 6.3`, and **exited 0**. The 6.3 stream disappeared from CI right after #56 (`chore: update to unity 6.3`) and took the coverage with it.

## The fix

Detection now uses two sources, because Docker Hub cannot tell you what is LTS:

1. **Unity's release API** (`services.api.unity.com/.../releases?stream=LTS`) — the only source that labels a stream LTS. Distinct `MAJOR.MINOR` streams come from it. `limit` caps at 25, but that window spans ~5 months, so every actively-released stream lands in it and an EOL stream drops out on its own.
2. **Docker Hub** — resolves each stream to the newest version game-ci has actually built, queried per stream with the `name` filter so that stream's tags are always on page 1.

Version patterns derive from the stream string instead of a baked-in `6000\.`, so a future major needs no edit here.

`version-streams` is gone from `test.yml`. It survives as an *optional* override for pinning and still accepts the old `6.0` short form alongside canonical `6000.0`.

### Failure semantics

game-ci lagging a fresh Unity LTS release is normal and transient, so the two modes treat a miss differently:

| Situation | Behavior |
| --- | --- |
| Auto: LTS stream with no image yet | `::warning`, continue |
| Auto: no stream resolves at all | `::error`, exit 1 |
| Pinned: requested stream has no image | `::error`, exit 1 (config bug) |
| Unity API unreachable | `::error`, exit 1 |

The silent-warning-and-continue behavior is what let this hide for two releases, so a matrix that would come back empty now breaks the build.

## Also here: only run tests when the Unity project changes

Docs and unrelated CI edits were spinning up the full editor matrix. The `'**.md'` paths-ignore is replaced with an explicit `paths` list:

```yaml
paths:
  - 'Assets/**'
  - 'Packages/**'
  - 'ProjectSettings/**'
  - '.github/workflows/test.yml'
  - '.github/workflows/detect-unity-versions.yml'
  - '!**.md'
```

`Packages/**` and `ProjectSettings/**` are matched wholesale rather than enumerated — the vendored packages compile alongside ours and can break a run on their own, and a wildcard cannot go stale when a new manifest appears. `Assets/**` is in because the tests compile with `ENABLE_ADDRESSABLES` and run against the Addressables config there. The two workflow files are in deliberately: without them this PR would not run tests at all.

Replayed over the last 12 merged PRs:

```
SKIPS  #65 #64 #63 #61 #60 #59    docs / unrelated CI
RUNS   #58 #57 #56 #55 #53 #50    actual Unity project changes
```

Half stop spinning up the editor matrix, with no false skips. `schedule` and `workflow_dispatch` ignore path filters, so the monthly regression run is unaffected.

## Verification

Every path was exercised by extracting the real `run:` block out of the YAML — not a hand-copy — and executing it against the live APIs:

```
AUTO (new default)          exit 0  ["6000.0.80f1","6000.3.20f1"]
PINNED 6000.0,6000.3        exit 0  ["6000.0.80f1","6000.3.20f1"]
PINNED 6.0,6.3 (legacy)     exit 0  ["6000.0.80f1","6000.3.20f1"]
PINNED bogus stream         exit 1  ::error
AUTO + stream lacking image exit 0  ::warning, matrix keeps the real versions
AUTO + nothing resolves     exit 1  ::error
Unity API unreachable       exit 1  ::error
```

Auto-detect independently arrives at the same two streams that were hardcoded, so this is a no-op for today's matrix — it just stops being a manual edit when the next stream goes LTS.

CI on this branch previously confirmed the real outcome: **two** playmode jobs instead of one, both green, with `6000.3.20f1` passing 286/286 on its first run since #56.

## Notes for review

- **The matrix can now grow on its own.** Once Unity promotes a new LTS stream and game-ci publishes images, CI picks it up without a PR and may go red on a genuinely untested version. That is the intent, but a red build can now originate outside your commits.
- **One version reference stays in `test.yml`**, deliberately: `if: startsWith(matrix.unityVersion, '6000.0')` -> `cp Packages/manifest.6.0.json`. That is pinned to a real file in `Packages/`, so a new stream correctly falls through to the default manifest.
- Typed `ci:` so the angular commit-analyzer does not cut a release, and named the branch `ci/...` rather than `fix/...` to stay off the prerelease branch patterns in `.releaserc.json`.
- **Scope:** LTS only. Testing the latest non-LTS stable stream is split out into #68, stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)