### PR TITLE
docs: drop the stale pt-BR version label override

### DIFF
--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
@@ -1,8 +1,4 @@
 {
-  "version.label": {
-    "message": "4.0.0",
-    "description": "The label for version current"
-  },
   "sidebar.documentationSidebar.category.Getting Started": {
     "message": "Começando",
     "description": "The label for category Getting Started in sidebar documentationSidebar"


### PR DESCRIPTION
Follow-up to #64. The version dropdown still reads **`4.0.0`** in Portuguese — a full minor behind English.

`i18n/pt-BR/docusaurus-plugin-content-docs/current.json` carried its own `version.label` override, generated by `write-translations`, which shadows the value in `docusaurus.config.js`. So #64's label change reached English but never reached pt-BR:

| Locale | Before | After |
|---|---|---|
| `/docs/intro` | `4.1.x` | `4.1.x` |
| `/pt-BR/docs/intro` | **`4.0.0`** | `4.1.x` |

Removed the key rather than syncing it to `4.1.x`. A version number isn't locale-specific, and with no override present Docusaurus falls back to the config label — so the two can't drift apart again. If `write-translations` regenerates the key later it picks up whatever the config says at that moment.

The frozen `3.1.0` label is untouched: it lives in its own `version-3.1.0.json` and correctly stays pinned.

## Verification

`npm run build` passes against the merged `docs` base (Docusaurus 3.10.2). Confirmed in the built output that both locales render `4.1.x` and `/pt-BR/docs/3.1.0/intro` still renders `3.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)