### PR TITLE
ci: add dependabot for the documentation site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+
+# The documentation site lives on the `docs` branch, but Dependabot only reads
+# this file from the default branch — hence the `target-branch` on every entry.
+# Nothing here touches the Unity package on `main`.
+updates:
+  - package-ecosystem: npm
+    directory: /
+    target-branch: docs
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    labels:
+      - dependencies
+      - documentation
+    groups:
+      # Docusaurus is a monorepo: bumping core without the preset and themes
+      # breaks the build, so they have to move together.
+      docusaurus:
+        patterns:
+          - '@docusaurus/*'
+      react:
+        patterns:
+          - react
+          - react-dom
+          - '@mdx-js/*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: docs
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - documentation
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Keeps the `docs` site's dependencies current. Docusaurus had drifted a year behind (3.8.1 → 3.10.2 in #63) with nothing watching it.

## Why this lands on `main`

Dependabot only reads `.github/dependabot.yml` from the **default branch**, so a config placed on `docs` would be ignored entirely. Every entry therefore carries `target-branch: docs` — Dependabot reads the manifests from `docs` and opens its PRs against `docs`.

**Nothing here touches the Unity package.** No entry targets `main`, so this won't start opening PRs against the package's own workflows or dependencies.

## What it watches

| Ecosystem | Manifest | Cadence |
|---|---|---|
| `npm` | `package.json` / `package-lock.json` on `docs` | monthly, max 5 open |
| `github-actions` | the actions pinned in `web-deploy.yml` | monthly |

Docusaurus packages are **grouped** into one PR. They're a monorepo released in lockstep — bumping `@docusaurus/core` without `preset-classic` and `theme-mermaid` breaks the build, which is exactly the sort of PR that sits unmerged. `react`/`react-dom`/`@mdx-js/*` are grouped for the same reason.

The Actions entry matters more than it looks: `web-deploy.yml` was still on `checkout@v4` and Node 18 until #63.

## Side effect worth knowing

`release.yml` triggers on any push to `main` with `paths-ignore: ['**.md']`, so merging this **will** fire the Release workflow. The commit is typed `ci:`, which the angular preset doesn't treat as releasable, so semantic-release will run and no-op — no tag, no version bump. Just a workflow run you can ignore.

## Note

Dependabot will create the `dependencies` label on first run; `documentation` already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)